### PR TITLE
Fix wrong link to install page 

### DIFF
--- a/content/getting-started/next.md
+++ b/content/getting-started/next.md
@@ -17,7 +17,7 @@ draft: false
 toc: true
 ---
 
-OK so you have [got the jx CLI](getting-started/install/) and you either 
+OK so you have [got the jx CLI](/getting-started/install/) and you either
 
 * [created a Kubernetes cluster with Jenkins X](/getting-started/install-on-cluster/)
 * [installed Jenkins X on an existing kubernetes cluster](/getting-started/install-on-cluster/)


### PR DESCRIPTION
I fixed wrong link:

#### before
http://localhost:1313/getting-started/next/getting-started/install/

#### after
http://localhost:1313/getting-started/install/