### PR TITLE
EKS no longer "coming soon". Removed spurious "or KES (sic)".

### DIFF
--- a/content/commands/jx_create_cluster.md
+++ b/content/commands/jx_create_cluster.md
@@ -23,10 +23,8 @@ Valid kubernetes providers include:
     * oke (Oracle Cloud Infrastructure Container Engine for Kubernetes - https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm)
     * kubernetes for custom installations of Kubernetes
     * minikube (single-node Kubernetes cluster inside a VM on your laptop)
-	* minishift (single-node OpenShift cluster inside a VM on your laptop)
-	* openshift for installing on 3.9.x or later clusters of OpenShift
-    * coming soon:
-        eks (Amazon Elastic Container Service - https://aws.amazon.com/eks)     
+    * minishift (single-node OpenShift cluster inside a VM on your laptop)
+    * openshift for installing on 3.9.x or later clusters of OpenShift
 
 Depending on which cloud provider your cluster is created on possible dependencies that will be installed are: 
 

--- a/content/commands/jx_update_cluster.md
+++ b/content/commands/jx_update_cluster.md
@@ -21,10 +21,9 @@ Valid kubernetes providers include:
     * oke (Oracle Cloud Infrastructure Container Engine for Kubernetes - https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm)
     * kubernetes for custom installations of Kubernetes
     * minikube (single-node Kubernetes cluster inside a VM on your laptop)
-	* minishift (single-node OpenShift cluster inside a VM on your laptop)
-	* openshift for installing on 3.9.x or later clusters of OpenShift
-    * coming soon:
-        eks (Amazon Elastic Container Service - https://aws.amazon.com/eks)    
+    * minishift (single-node OpenShift cluster inside a VM on your laptop)
+    * openshift for installing on 3.9.x or later clusters of OpenShift
+
 
 ```
 jx update cluster [kubernetes provider] [flags]

--- a/content/getting-started/config.md
+++ b/content/getting-started/config.md
@@ -48,7 +48,7 @@ chartmuseumServiceLink:
 
 ## Docker Registry
 
-We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS or KES. 
+We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS. 
 
 However you can also specify this via the `--docker-registry` option when running  [jx create cluster](/commands/jx_create_cluster) or [jx install](/commands/jx_install)
 

--- a/content/getting-started/config.zh.md
+++ b/content/getting-started/config.zh.md
@@ -47,7 +47,7 @@ chartmuseumServiceLink:
 
 ## Docker Registry
 
-We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS or KES. 
+We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS. 
 
 然而，你也可以在执行命令 [jx create cluster](/commands/jx_create_cluster) 或 [jx install](/commands/jx_install) 时，通过选项 `--docker-registry` 来指定。
 


### PR DESCRIPTION
Removed EKS "coming soon" lines.

Changed "AWS or KES (sic)" to just "AWS", as kops clusters on EC2, and EKS are both just "AWS".