### PR TITLE
Added `jx upgrade cli` friendly installation instructions for Linux

### DIFF
--- a/content/getting-started/install.md
+++ b/content/getting-started/install.md
@@ -39,8 +39,10 @@ sudo mv jx /usr/local/bin
 ### Linux
 
 ```shell
-curl -L https://github.com/jenkins-x/jx/releases/download/v{{< version >}}/jx-linux-amd64.tar.gz | tar xzv 
-sudo mv jx /usr/local/bin
+mkdir -p ~/.jx/bin
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{< version >}}/jx-linux-amd64.tar.gz | tar xzv -C ~/.jx/bin
+export PATH=$PATH:~/.jx/bin
+echo 'export PATH=$PATH:~/.jx/bin' >> ~/.bashrc
 ```
     
 ### Other platforms


### PR DESCRIPTION
Hi,

Right now jx installation instructions are not in sync with `jx upgrade cli` - https://jenkins-x.io/getting-started/install/ . `jx upgrade cli` installs upgraded binary in `~/.jx/bin` which may even not be in your PATH. Also `jx upgrade cli` won't (and can't) remove `/usr/local/bin/jx` file, so effectively upgrade is not working.

I propose to improve instructions to copy initial binary straight into `~/.jx/bin` and updating bashrc with the proper PATH entry. With this approach `jx upgrade cli` is gonna work as expected. Plus all the other binary dependencies pulled by jx (like eksctl, helm or kubectl) will be available in the PATH.