### PR TITLE
Use a correct URL to the workspace and add a note about signup.

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -19,10 +19,14 @@ Please join us in the community, we'd love to hear your feedback!
 
 ## Slack
 
-The Kubernetes community [hangs out on Slack](http://slack.k8s.io/) at [slack.k8s.io](http://slack.k8s.io/) so we have rooms there to chat about all things Jenkins X:
+The Kubernetes community [hangs out on Slack](http://slack.k8s.io/) at [kubernetes.slack.com](https://kubernetes.slack.com/) so we have rooms there to chat about all things Jenkins X:
 
 * [\#jenkins-x-user](https://kubernetes.slack.com/messages/C9MBGQJRH) for users of Jenkins X
 * [\#jenkins-x-dev](https://kubernetes.slack.com/messages/C9LTHT2BB) for developers of Jenkins X
+
+{{% note %}}
+If you do not already have an account created for the `kubernetes` workspace you can create one by clicking [`GET MY INVITE`](http://slack.k8s.io/)
+{{% /note %}}
 
 ## Office Hours
 


### PR DESCRIPTION
It was not obvious to me where I had to signup as I clicked directly on
the room link.  Also given I already has a slack account for a different
workspace trying to add the new workspace was not obvious because
slack.k8s.io is not really a slack workspace, so changed the second URL
to be the workspace URL and not a vanity one.