### PR TITLE
Add IBM Cloud as of 1.3.x

### DIFF
--- a/content/contribute/roadmap.md
+++ b/content/contribute/roadmap.md
@@ -31,7 +31,7 @@ toc: true
 | Azure | | | | 1.1.x |
 | Digital Ocean  | | [Planned](https://github.com/jenkins-x/jx/issues/705) | | |
 | GKE | | | | 1.1.x |
-| IBM Cloud  | | [Planned](https://github.com/jenkins-x/jx/issues/472) | | |
+| IBM Cloud  | | | | 1.3.x|
 | Minkube | | | | 1.1.x |
 | Minishift | | | | 1.2.11 |
 | OKE | | Planned | | |


### PR DESCRIPTION
The now merged PRs being https://github.com/jenkins-x/jx/pull/2073 for IBM Cloud Private and https://github.com/jenkins-x/jx/pull/1965 for the IBM Cloud Kubernetes Service.