### PR TITLE
fixes custom builder example so docker build succeeds

### DIFF
--- a/content/getting-started/create-custom-builder.md
+++ b/content/getting-started/create-custom-builder.md
@@ -33,7 +33,7 @@ FROM jenkinsxio/builder-base:latest
 # Install your tools and libraries
 RUN yum install -y gcc openssl-devel
 
-CMD["gcc"]
+CMD ["gcc"]
 ```
 
 Now you can build the image and publish it to your registry:

--- a/content/getting-started/create-custom-builder.zh.md
+++ b/content/getting-started/create-custom-builder.zh.md
@@ -31,7 +31,7 @@ FROM jenkinsxio/builder-base:latest
 # Install your tools and libraries
 RUN yum install -y gcc openssl-devel
 
-CMD["gcc"]
+CMD ["gcc"]
 ```
 
 现在，您可以构建并发布这个镜像到您的 registry：


### PR DESCRIPTION
Error this fixes:
```
Error response from daemon: Dockerfile parse error line 9: unknown instruction: CMD["GCC"]
```