### PR TITLE
Fix formatting of code blocks in testing section of contributing docs

### DIFF
--- a/content/contribute/development.md
+++ b/content/contribute/development.md
@@ -324,16 +324,24 @@ The jx test suite is divided into three sections:
  - Integration tests
 
 To run the standard test suite:
-```$ make test```
+```shell
+$ make test
+```
 
 To run the standard test suite including slow running tests:
-```$ make test-slow```
+```shell
+$ make test-slow
+```
 
 To run all tests including integration tests (NOTE These tests are not encapsulated):
-```$ make test-slow-integration```
+```shell
+$ make test-slow-integration
+```
 
 To get a nice HTML report on the tests:
-```$ make test-report-html```
+```shell
+$ make test-report-html
+```
 
 ### Writing tests
 


### PR DESCRIPTION
The code blocks for the testing section are not formatted correctly, which results in some text and shell commands getting displayed incorrectly:
<img width="411" alt="screen shot 2018-11-30 at 14 51 02" src="https://user-images.githubusercontent.com/1068968/49312227-7d195100-f4b1-11e8-8072-1b57fb0527d2.png">

I added a newline after the 3 backticks and marked each block for `shell` syntax highlighting to be consistent with the rest of the page. Here is what it the docs look like with my changes:
<img width="375" alt="screen shot 2018-11-30 at 15 01 41" src="https://user-images.githubusercontent.com/1068968/49312346-e8fbb980-f4b1-11e8-870e-230f64f3d0a9.png">
