### PR TITLE
Fix link for 'jx get applications'

### DIFF
--- a/content/developing/browsing.md
+++ b/content/developing/browsing.md
@@ -82,7 +82,7 @@ jx get pipelines
 
 ### Applications
 
-To view all the applications in your team across all your environments with URLs and pod counts use  [jx get applications](/commands/applications):
+To view all the applications in your team across all your environments with URLs and pod counts use  [jx get applications](/commands/jx_get_applications):
 
 ```shell
 jx get applications


### PR DESCRIPTION
Fixes 404 on https://jenkins-x.io/developing/browsing/ pointing to https://jenkins-x.io/commands/applications