### PR TITLE
Update Google Analytics ID

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ metaDataFormat = "yaml"
 title = "Jenkins X"
 theme = "gohugoioTheme"
 
-googleAnalytics = "UA-4216293-5"
+googleAnalytics = "UA-4216293-7"
 
 canonifyURLs=true
 pluralizeListTitles = false


### PR DESCRIPTION
Resulting in a dedicated jenkins-x.io Google Analytics property (separated from jenkins.io)