### PR TITLE
Notes on order of entries in requitements.yaml/dependecies array.

### DIFF
--- a/content/developing/preview.md
+++ b/content/developing/preview.md
@@ -51,9 +51,10 @@ You can find possible charts to install by searching helm. e.g. to find a `postg
 helm search postgres
 ```
 
-Once you know the chart and the repository its in you can add it to your `charts/preview/requirements.yaml` file (the `postgresql` section at the end of the file):
+Once you know the chart and the repository its in you can add it to your `charts/preview/requirements.yaml` file (the `postgresql` section in dependencies array):
 
 ```yaml
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -63,13 +64,20 @@ dependencies:
   name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
   version: 2.3.56
-- alias: preview
-  name: demo179
-  repository: file://../demo179
+
+  # Ephemeral PostgeSQL created in preview environment.
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.6.2
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
+- alias: preview
+  name: demo179
+  repository: file://../demo179
+
 ```
+Note: `- alias: preview` must be last entry in dependecies array and `requirements.yaml` file must end with empty line.
 
 ### Service Linking
 


### PR DESCRIPTION
1. I want to fix example with postresql as a preview dependency. The example does not work. Error wold be "Can't get a valid version for repositories postgresql". It is due to how charts/preview/Makefile appends `$(PREVIEW_VERSION)` into requirements.yaml:

        ...
        echo "  version: $(PREVIEW_VERSION)" >> requirements.yaml
        jx step helm build

Also due to this `requirements.yaml` must end with an empty line.

2. I want to add my finding into documentation on how to order entries requirements.yam to prevent errors in preview environment build.

### Jx version

The output of `jx version` is:

```
NAME               VERSION
jx                 1.3.688
jenkins x platform 0.0.3125
Kubernetes cluster v1.10.9-gke.5
kubectl            v1.10.7
helm client        v2.12.1+g02a47c7
helm server        v2.12.1+g02a47c7
git                git version 2.11.0
Operating System   Debian GNU/Linux 9.6 (stretch)
```