### PR TITLE
Update GKE "Connecting to the cluster from your laptop" section

### DIFF
--- a/content/getting-started/create-cluster.md
+++ b/content/getting-started/create-cluster.md
@@ -80,7 +80,11 @@ Use the [jx create cluster gke](/commands/jx_create_cluster_gke) command:
 
     jx create cluster gke --verbose
 
-The command assumes you have a google account and you've set up a default project that you can use to create the kubernetes cluster within.         
+Or if you are already logged in by previously using `gcloud init` or `gcloud auth login`:
+
+    jx create cluster gke --skip-login --verbose
+
+Those commands assume you have a google account and you've set up a default project that you can use to create the kubernetes cluster within.         
 Now **[develop apps faster with Jenkins X](/getting-started/next/)**.
 
 


### PR DESCRIPTION
Who is following this guide might find a gcloud login error(like I did) when using `jx create cluster gke` if they were already logged in at gcloud, specially if they followed Google's gcloud tool installation guide that we provided at jx's dependency verification phase. 

This new instruction might help them until there's a specific error handling code about this case.