### PR TITLE
Fix small typos

### DIFF
--- a/content/architecture/storage.md
+++ b/content/architecture/storage.md
@@ -51,7 +51,7 @@ e.g.
 jx edit storage -c tests --bucket-url s3://myExistingBucketName
   
 # Configure the git URL and branch of where to store logs
-jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git' --git-branch cheese
+jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git --git-branch cheese
 ```
 
 You can view your teams storage settings via [jx get storage](/commands/jx_get_storage/)

--- a/content/commands/jx_edit_storage.md
+++ b/content/commands/jx_edit_storage.md
@@ -38,13 +38,13 @@ jx edit storage [flags]
   
   
   # Configure the git URL of where to store logs (defaults to gh-pages branch)
-  jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git'
+  jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git
   
   # Configure the git URL and branch of where to store logs
-  jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git' --git-branch cheese
+  jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git --git-branch cheese
   
   # Configure the git URL of where all storage goes to by default unless a specific classifier has a config
-  jx edit storage -c default --git-url https://github.com/myorg/mylogs.git'
+  jx edit storage -c default --git-url https://github.com/myorg/mylogs.git
   
   
   # Configure the tests to be stored in cloud storage (using S3 / GCS / Azure Blobs etc)


### PR DESCRIPTION
These examples wouldn't work when copying & pasting on a user's system
because of the trailing quote.