### PR TITLE
jx create user flags incorrect in example

### DIFF
--- a/content/architecture/rbac.md
+++ b/content/architecture/rbac.md
@@ -37,7 +37,7 @@ Jenkins X ships with a bunch of default `Role` objects you can use in the `jenki
 To add users use the [jx create user](/commands/jx_create_user/) command:
 
 ```shell
-jx create user -e "user@email.com" --login login --name username" 
+jx create user -e "user@email.com" --login username --name "User Name" 
 ```
 
 ## Changing user roles


### PR DESCRIPTION
Updating user creation example to be more clear:

--login denotes the username, login as a username was confusing
--name denotes display name, "username" was confusing