### PR TITLE
Missing link for "created a Kubernetes cluster with Jenkins X"

### DIFF
--- a/content/getting-started/next.md
+++ b/content/getting-started/next.md
@@ -19,7 +19,7 @@ toc: true
 
 OK so you have [got the jx CLI](/getting-started/install/) and you either
 
-* [created a Kubernetes cluster with Jenkins X](/getting-started/install-on-cluster/)
+* created a Kubernetes cluster with Jenkins X
 * [installed Jenkins X on an existing kubernetes cluster](/getting-started/install-on-cluster/)
 
 So whats next?


### PR DESCRIPTION
This is not actually PR, but bug as link is missing for "created a Kubernetes cluster with Jenkins X"