### PR TITLE
Remove the subtle wording around golang version

### DIFF
--- a/content/contribute/development.md
+++ b/content/contribute/development.md
@@ -40,7 +40,7 @@ If you're struggling at any point in this contribution guide, reach out to the J
 To contribute to Jenkins X jx binary, you will need:
 
  - [Git](https://git-scm.com) and a [GitHub](https://github.com) account
- - [Go](https://golang.org/) `1.11.4` or later, with support for compiling to `linux/amd64`
+ - [Go](https://golang.org/) `1.11.4`, with support for compiling to `linux/amd64`
  
 
 ## Install Go


### PR DESCRIPTION
At present 1.11.4 seems to be a known version of golang where go modules behave as expected.