### PR TITLE
Highlight ChartMuseum config with header

### DIFF
--- a/content/getting-started/config.md
+++ b/content/getting-started/config.md
@@ -37,6 +37,8 @@ nexusServiceLink:
   externalName: "nexus.jx.svc.cluster.local"
 ```
 
+## ChartMuseum
+
 To disable and service link chart museum add:
 
 ```yaml


### PR DESCRIPTION
In Getting Started / Configuration page make it clear that ChartMuseum can be overridden by adding a header