### PR TITLE
remove aliases from Chinese pages

### DIFF
--- a/content/about/accelerate.zh.md
+++ b/content/about/accelerate.zh.md
@@ -12,7 +12,6 @@ menu:
 weight: 10
 sections_weight: 0
 draft: false
-aliases: [/about/accelerate]
 categories: [fundamentals]
 toc: true
 ---

--- a/content/about/concepts.zh.md
+++ b/content/about/concepts.zh.md
@@ -12,7 +12,6 @@ menu:
 weight: 20
 sections_weight: 20
 draft: false
-aliases: [/about/concepts]
 categories: [fundamentals]
 toc: true
 ---

--- a/content/about/features.zh.md
+++ b/content/about/features.zh.md
@@ -12,7 +12,6 @@ menu:
 weight: 5
 sections_weight: 5
 draft: false
-aliases: [/about/features]
 categories: [fundamentals, 基础]
 toc: true
 ---

--- a/content/about/license.zh.md
+++ b/content/about/license.zh.md
@@ -13,7 +13,6 @@ menu:
     weight: 60
 weight: 60
 sections_weight: 60
-aliases: [/meta/license]
 toc: true
 ---
 

--- a/content/architecture/_index.zh.md
+++ b/content/architecture/_index.zh.md
@@ -13,6 +13,5 @@ menu:
     weight: 1
 weight: 1
 draft: false
-aliases: [/architecture/]
 toc: false
 ---

--- a/content/contribute/_index.zh.md
+++ b/content/contribute/_index.zh.md
@@ -14,7 +14,6 @@ menu:
 weight: 01	#rem
 draft: false
 slug:
-aliases: [/community/contributing/]
 toc: false
 ---
 

--- a/content/contribute/apidocs.zh.md
+++ b/content/contribute/apidocs.zh.md
@@ -14,7 +14,6 @@ menu:
 weight: 20
 sections_weight: 20
 draft: false
-aliases: [/contribute/apidocs/]
 toc: true
 ---
 

--- a/content/contribute/development.zh.md
+++ b/content/contribute/development.zh.md
@@ -15,7 +15,6 @@ menu:
 weight: 10
 sections_weight: 10
 draft: false
-aliases: [/contribute/development/]
 toc: true
 ---
 

--- a/content/contribute/documentation.zh.md
+++ b/content/contribute/documentation.zh.md
@@ -14,7 +14,6 @@ menu:
 weight: 20
 sections_weight: 20
 draft: false
-aliases: [/contribute/docs/]
 toc: true
 ---
 

--- a/content/contribute/roadmap.zh.md
+++ b/content/contribute/roadmap.zh.md
@@ -14,7 +14,6 @@ menu:
 weight: 20
 sections_weight: 20
 draft: false
-aliases: [/contribute/roadmap/,/contribute/futures/]
 categories: [fundamentals, 基础]
 toc: true
 ---

--- a/content/contribute/triage.zh.md
+++ b/content/contribute/triage.zh.md
@@ -15,7 +15,6 @@ menu:
 weight: 30
 sections_weight: 30
 draft: false
-aliases: [/contribute/triage/]
 toc: true
 ---
 

--- a/content/demos/_index.zh.md
+++ b/content/demos/_index.zh.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 weight: 1
 draft: false
-aliases: [/demos/]
 toc: false
 ---
 

--- a/content/developing/_index.zh.md
+++ b/content/developing/_index.zh.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 weight: 1
 draft: false
-aliases: [/developing/]
 toc: false
 ---
 

--- a/content/developing/promote.zh.md
+++ b/content/developing/promote.zh.md
@@ -13,7 +13,6 @@ weight: 100
 sections_weight: 100
 draft: false
 toc: true
-aliases: [/developing/promotion/]
 ---
 
 

--- a/content/faq/develop.zh.md
+++ b/content/faq/develop.zh.md
@@ -10,7 +10,6 @@ menu:
 keywords: [faqs]
 weight: 15
 toc: true
-aliases: [/faq/]
 ---
 
 ## 如何注入特定的环境配置

--- a/content/faq/faq.zh.md
+++ b/content/faq/faq.zh.md
@@ -10,7 +10,6 @@ menu:
 keywords: [faqs]
 weight: 2
 toc: true
-aliases: [/faq/]
 ---
 
 我们已经试图把一些常见的问题整理到这里。如果你遇到的问题没有在这里列出来，请[让我们知道](https://github.com/jenkins-x/jx/issues/new)。

--- a/content/faq/issues.zh.md
+++ b/content/faq/issues.zh.md
@@ -10,7 +10,6 @@ menu:
 keywords: [faqs]
 weight: 4
 toc: true
-aliases: [/faq/]
 ---
 
 我们已经试图把一些常见的问题整理到这里。如果你遇到的问题没有在这里列出来，请[让我们知道](https://github.com/jenkins-x/jx/issues/new)。

--- a/content/faq/jenkins.zh.md
+++ b/content/faq/jenkins.zh.md
@@ -10,7 +10,6 @@ menu:
 keywords: [jenkins]
 weight: 2
 toc: true
-aliases: [/jenkins/]
 ---
 
 # 密码

--- a/content/faq/setup.zh.md
+++ b/content/faq/setup.zh.md
@@ -10,7 +10,6 @@ menu:
 keywords: [faqs]
 weight: 2
 toc: true
-aliases: [/faq/]
 ---
 
 ## 如何在 Jenkins X 的安装当中添加用户？

--- a/content/faq/technology.zh.md
+++ b/content/faq/technology.zh.md
@@ -10,7 +10,6 @@ menu:
 keywords: [faqs]
 weight: 10
 toc: true
-aliases: [/faq/]
 ---
 
 ## 什么是 Helm?

--- a/content/getting-started/_index.zh.md
+++ b/content/getting-started/_index.zh.md
@@ -14,7 +14,6 @@ menu:
 weight: 0001	#rem
 sections_weight: 10
 draft: false
-aliases: [/overview/introduction/]
 toc: false
 ---
 

--- a/content/news/_index.zh.md
+++ b/content/news/_index.zh.md
@@ -1,4 +1,3 @@
 ---
 title: "Jenkins X 新闻"
-aliases: [/release-notes/]
 ---


### PR DESCRIPTION
The aliases where bogus as we had not been generating them for GH Pages
for a long time.  On top of that when we start generating them they
overwrite the English pages as they missed the /zh/ prefix.

Rather than add /zh/ prefix we just remove them as the links would have
been dead for a long time anyway and this is an opertunity to cleanup