### PR TITLE
Fix AWS IAM Policy for Vault user to get access to KMS key

### DIFF
--- a/content/getting-started/aws-terraform-install-gitops.md
+++ b/content/getting-started/aws-terraform-install-gitops.md
@@ -158,7 +158,8 @@ data "aws_iam_policy_document" "vault" {
         effect = "Allow"
         actions = [
             "kms:Encrypt",
-            "kms:Decrypt"
+            "kms:Decrypt",
+            "kms:DescribeKey"
         ]
         resources = ["${aws_kms_key.bank_vault.arn}"]
     }}


### PR DESCRIPTION
Fix AWS IAM Policy for Vault user to get access to KMS key
If you try to use this terraform as is your `vault` containers will never start.
And stuck in a loop with logs like this
```
Error parsing Seal configuration: error fetching AWS KMS sealkey information: AccessDeniedException: User: arn:aws:iam::<account-id>:user/vault_<region-name> is not authorized to perform: kms:DescribeKey on resource: arn:aws:kms:<region-name>:<account-id>:key/<key-id>
	status code: 400, request id: <id>
```