### PR TITLE
fix: Fixing a documentation error with getting password

### DIFF
--- a/content/architecture/custom-jenkins.md
+++ b/content/architecture/custom-jenkins.md
@@ -53,7 +53,7 @@ So to find the password you will need to find it by hand I'm afraid.
 * type the following (you may need to change the `Secret` name if you use a different alias for your Jenkins server):
 
 ```shell
-kubectl get secret jx-jx-app-jenkins | ksd
+kubectl get secret jx-jx-app-jenkins -o yaml | ksd
 ```
 
 Then you will see your user/pwd on the screen if you want to login to the Jenkins UI via [jx console](/commands/jx_console/)


### PR DESCRIPTION
The command that is currently in the documentation gives the following error:

```
could not decode secret: yaml: unmarshal errors:
  line 1: cannot unmarshal !!str `NAME   ...` into main.secret
```