### PR TITLE
docs: fix syntax error in Terraform example

### DIFF
--- a/content/getting-started/aws-terraform-install-gitops.md
+++ b/content/getting-started/aws-terraform-install-gitops.md
@@ -162,7 +162,8 @@ data "aws_iam_policy_document" "vault" {
             "kms:DescribeKey"
         ]
         resources = ["${aws_kms_key.bank_vault.arn}"]
-    }}
+    }
+}
 
 resource "aws_iam_user_policy" "vault" {
     name = "vault_${var.region}"


### PR DESCRIPTION
The current Terraform "Getting Started" guide has a syntax error in the Vault IAM policy resource:
```
Error: Missing newline after block definition
```

This is easily fixed by moving the closing brace for the resource to a newline.