### PR TITLE
Remove weirdly encoded space that would mess with the markdown rendering

### DIFF
--- a/content/faq/pipelines.md
+++ b/content/faq/pipelines.md
@@ -23,7 +23,7 @@ To add a new custom step to your `jenkins-x.yml` file see [how to use the jx cre
 
 See [the differences between Jenkins X and Jenkins Pipelines](/architecture/jenkins-x-pipelines/#differences-to-jenkins-pipelines)
 
-## How do I get IDE completion editing `jenkins-x.yml`
+## How do I get IDE completion editing `jenkins-x.yml`
 
 See the IDE guide for [IDEA](/architecture/jenkins-x-pipelines/#editing-in-vs-code) and [VS Code](/architecture/jenkins-x-pipelines/#editing-in-vs-code) 
 


### PR DESCRIPTION
There is a weirdly encoded space that causes the markdown to render incorrectly, this change simply replaces it with a regular space. 

## Screenshot of issue in rendering
src: https://jenkins-x.io/faq/pipelines/
![image](https://user-images.githubusercontent.com/2390653/64881612-31dbc380-d629-11e9-921d-3906cafea7be.png)
