### PR TITLE
Removing console errors

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -174,7 +174,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 79 88" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 79 88" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-192.000000, -1133.000000)" fill="#73C3D5"
@@ -203,7 +203,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 93 92" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 93 92" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-782.000000, -1127.000000)">
@@ -245,7 +245,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 71 89" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 71 89" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-205.000000, -1390.000000)" fill="#73C3D5"
@@ -298,7 +298,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 95 90" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 95 90" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-782.000000, -1383.000000)">

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -453,13 +453,4 @@ linkTitle = "Jenkins X"
     </div>
   </section>
 </main>
-
-
-<!-- Bootstrap core JavaScript
-  ================================================== -->
-<!-- Placed at the end of the document so the pages load faster -->
-<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-  integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-  crossorigin="anonymous"></script>
-  <script src="/dist/app.bundle.js"></script>
 </body>

--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -429,13 +429,4 @@ linkTitle = "Jenkins X"
     </div>
   </section>
 </main>
-
-
-<!-- Bootstrap core JavaScript
-  ================================================== -->
-<!-- Placed at the end of the document so the pages load faster -->
-<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-  integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-  crossorigin="anonymous"></script>
-  <script src="/dist/app.bundle.js"></script>
 </body>

--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -151,7 +151,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 79 88" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 79 88" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-192.000000, -1133.000000)" fill="#73C3D5"
@@ -180,7 +180,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 93 92" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 93 92" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-782.000000, -1127.000000)">
@@ -222,7 +222,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 71 89" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 71 89" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-205.000000, -1390.000000)" fill="#73C3D5"
@@ -275,7 +275,7 @@ linkTitle = "Jenkins X"
         <div class="col pt-2">
           <div class="media">
             <span>
-              <svg width="79px" height="auto" viewBox="0 0 95 90" version="1.1" xmlns="http://www.w3.org/2000/svg"
+              <svg width="79px" viewBox="0 0 95 90" version="1.1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Jenkins.io" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                   <g id="Desktop-(Bootstrap-xxl)" transform="translate(-782.000000, -1383.000000)">


### PR DESCRIPTION
Removed reference to a app.bundle.js which is part of bootstrap, so already included

Removed height on SVG icons on front page; doesn't seem to be needed