### PR TITLE
fix: Fix broken link in the Getting Started guide

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -8,7 +8,7 @@ aliases:
   - /getting-started
 ---
 
-The simplest way to get started is via the [Google Cloud Tutorials](tutorials).
+The simplest way to get started is via the [Google Cloud Tutorials](/docs/managing-jx/tutorials/google-hosted.md).
 
 Otherwise first you will need to [get the jx command line tool](install) locally on your machine.
 

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -8,7 +8,7 @@ aliases:
   - /getting-started
 ---
 
-The simplest way to get started is via the [Google Cloud Tutorials](/docs/managing-jx/tutorials/google-hosted.md).
+The simplest way to get started is via the [Google Cloud Tutorials](/docs/managing-jx/tutorials/google-hosted/).
 
 Otherwise first you will need to [get the jx command line tool](install) locally on your machine.
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

This PR fixes the link to 'Google Cloud Tutorials' in the 'Getting Started' guide.