### PR TITLE
docs: update link to Contribute page in different language versions

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -438,7 +438,7 @@ linkTitle = "Jenkins X"
           </span>
           <h2>Contributors welcome</h2>
           <p>We value every contribution. Join us on GitHub to learn how you can help.</p>
-          <p><a class="btn btn-sm bg-primary text-light my-2" href="docs/contribution-guidelines/" role="button">Contribute</a></p>
+          <p><a class="btn btn-sm bg-primary text-light my-2" href="docs/contributing/" role="button">Contribute</a></p>
         </div><!-- /.col-lg-4 -->
 
         <div class="col-lg-4 text-center">

--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -71,7 +71,7 @@ linkTitle = "Jenkins X"
   .btn-primary {
     border: 2px solid #289CE1;
     background-color: #289CE1;
-  } 
+  }
 
   .features {
     height: 54px;
@@ -81,7 +81,7 @@ linkTitle = "Jenkins X"
     line-height: 54px;
     margin-bottom: 70px;
   }
-  
+
  @media (max-width: 576px) {
     .features {
       font-size: 32px;
@@ -96,7 +96,7 @@ linkTitle = "Jenkins X"
   }
 
   /* Type */
-  
+
   h2 {
     font-size: 28px;
     font-weight: 500;
@@ -414,7 +414,7 @@ linkTitle = "Jenkins X"
           </span>
           <h2>Contributors welcome</h2>
           <p>We value every contribution. Join us on GitHub to learn how you can help.</p>
-          <p><a class="btn btn-sm btn-primary my-2" href="docs/contribution-guidelines/" role="button">Contribute</a></p>
+          <p><a class="btn btn-sm btn-primary my-2" href="docs/contributing/" role="button">Contribute</a></p>
         </div><!-- /.col-lg-4 -->
 
         <div class="col-lg-4 text-center">


### PR DESCRIPTION
https://jenkins-x.io/docs/contribution-guidelines/
returns
![image](https://user-images.githubusercontent.com/373530/65552837-b8e04400-df25-11e9-8dac-c0824caef4cb.png)

This pull request fixes references to Contribute page and it is pointing to https://jenkins-x.io/docs/contributing/