### PR TITLE
fix: add hugo to the server command that starts local hugo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   server:
     image: dennisnewel/hugo-extended:0.58.3
-    command: ["server", "-s", "/src", "-D", "--bind", "0.0.0.0", "--ignoreCache"]
+    command: ["hugo", "server", "-s", "/src", "-D", "--bind", "0.0.0.0", "--ignoreCache"]
     volumes:
       - .:/src
     ports:


### PR DESCRIPTION
The hugo docker image was updated to change "hugo" from an entrypoint to a cmd, to allow other commands to be easily run from the command line; this will take that change into account