### PR TITLE
fix: Fixes broken link to Accelerate page

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -13,7 +13,7 @@ cascade:
 ## Concepts
 ---
 Jenkins X is designed to make it simple for developers to work to DevOps principles and best practices. The approaches taken
-are based on the comprehensive research done for the book [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). You can read why we use [Accelerate](../accelerate) for the principals behind Jenkins X.
+are based on the comprehensive research done for the book [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). You can read why we use [Accelerate](../docs/overview/accelerate/) for the principals behind Jenkins X.
 
 
 ## Principles


### PR DESCRIPTION
Currently when clicking on the accelerate link in the about page you get a 404. This PR changes that link to point the accelerate content in the overview section.