### PR TITLE
fix: add Highlight.js back in

### DIFF
--- a/content/en/about/maturity.md
+++ b/content/en/about/maturity.md
@@ -67,7 +67,7 @@ Experimental
 
 The `--help` command will include the information in the description of a command, like this:
 
-```cmd
+```sh
 Installing:
   profile          Set your jx profile
   boot             (Experimental) Boots up Jenkins X in a Kubernetes cluster using GitOps and a Jenkins X Pipeline

--- a/content/en/blog/news/jenkins-x-observability.md
+++ b/content/en/blog/news/jenkins-x-observability.md
@@ -2,7 +2,7 @@
 title: "Increasing CI/CD Pipeline Observability in Jenkins X"
 date: 2019-07-29T10:44:40-07:00
 description: >
-  Increase observability by activating metric capture and analysis during a containerized application deployment with Jenkins X. 
+  Increase observability by activating metric capture and analysis during a containerized application deployment with Jenkins X.
 categories: [blog]
 keywords: [observability,instrumentation, logs]
 slug: "jenkins-x-observability"
@@ -15,10 +15,10 @@ author: Oscar Medina
 <h5>Increasing CI/CD Pipeline Observability, implement tracing</h5>
 </figcaption>
 </figure>
-Credit: [Minds Eye Creative](https://www.mindseyecreative.ca/) | [DevOps Days Toronto](https://devopsdays.org/events/2018-toronto/program/clay-smith/) 
+Credit: [Minds Eye Creative](https://www.mindseyecreative.ca/) | [DevOps Days Toronto](https://devopsdays.org/events/2018-toronto/program/clay-smith/)
 
 # Overview
-You might have heard of Observability given that folks have been talking about this for a while now.  Sure, you might think it is just the latest tech buzzword.  However, the practice has been around for a long time now.  
+You might have heard of Observability given that folks have been talking about this for a while now.  Sure, you might think it is just the latest tech buzzword.  However, the practice has been around for a long time now.
 
 Observability is certainly relevant today given the Microservices architectures, distributed systems, and the characteristics of modern applications being deployed at a faster pace by leveraging CI/CD pipelines to Kubernetes, in this case using Jenkins X.  Indeed old practices of setting up monitoring after an app is deployed, are no longer acceptable.
 
@@ -27,7 +27,7 @@ Let’s face it, modern apps call for modern instrumentation, not only once they
 Given that Jenkins X is the native CI/CD platform for Kubernetes, we must start thinking of Observability in the context of the build and release of our containerized applications via this platform, and not after the deployment process itself.
 
 # What we are doing today
-Today, I walk you through the process of increasing observability in your build and release pipeline by implementing tracing for a couple of events such as `npm install` and `npm test` which are part of a sample NodeJS application.  
+Today, I walk you through the process of increasing observability in your build and release pipeline by implementing tracing for a couple of events such as `npm install` and `npm test` which are part of a sample NodeJS application.
 
 {{% alert %}}
 NOTE: Tracing is only a small portion of other things that need to be in place.  Logging and Metrics are also required.  The combination and aggregation of this data allows you to understand how observable your pipeline is.
@@ -45,7 +45,7 @@ Diagram by: [Peter Bourgon](https://peter.bourgon.org/blog/2017/02/21/metrics-tr
 
 ## Leveraging Third-Party Tools
 
-Jenkins X was built with extensibility and flexibility in mind.  Today, you can easily create **QuickStarts** for a language not implemented.  You can also build **addOns** to augment the platform functionality.  There are currently **addOns** for `istio`, `prometheus` and `anchore` to name a few.  Given this extensibility, we encourage our community to build these components and share with everyone.  
+Jenkins X was built with extensibility and flexibility in mind.  Today, you can easily create **QuickStarts** for a language not implemented.  You can also build **addOns** to augment the platform functionality.  There are currently **addOns** for `istio`, `prometheus` and `anchore` to name a few.  Given this extensibility, we encourage our community to build these components and share with everyone.
 
 If you look around, you’ll find that [Honeycomb.io](http://Honeycomb.io) is at the forefront of Observability.  We are collaborating with them to eventually have a _Honeycomb addOn_ for Jenkins X
 
@@ -53,7 +53,7 @@ In this post, we use the Honeycomb.io API to trace our pipeline events.
 
 
 ### Tracing CI/CD Pipeline Events
-In this scenario we want to trace start and end times for certain events.  In our example NodeJS app, we have commands such as `npm install` and `npm test`, which are part of our **build-pack** pipeline out of the box.  To do start tracing, we modify the Tekton pipeline and inject calls to the Honeycomb.io API before and after these specific **build pack** named steps.  
+In this scenario we want to trace start and end times for certain events.  In our example NodeJS app, we have commands such as `npm install` and `npm test`, which are part of our **build-pack** pipeline out of the box.  To do start tracing, we modify the Tekton pipeline and inject calls to the Honeycomb.io API before and after these specific **build pack** named steps.
 
 
 {{% alert %}}
@@ -64,8 +64,8 @@ NOTE: Please be sure to sign up for [honeycomb.io](http://honeycomb.io) to obtai
 #### Create Kubernetes Secret
 Once we have our API Key, we want to create a Kubernetes Secret which is required to make API calls within our pipeline.  To do this, we create it in the `jx` and `jx-staging` namespaces.  For each namespace execute the following command (be sure to modify the namespace value as needed).
 
-```bash
->$ kubectl create secret generic honeycomb-creds —from-literal=BUILDEVENT_APIKEY=<KEY>  --namespace=<NAMESPACE>
+```sh
+kubectl create secret generic honeycomb-creds —from-literal=BUILDEVENT_APIKEY=<KEY> --namespace=<NAMESPACE>
 ```
 #### Modify Tekton Pipeline
 Now that we have our Kubernetes Secret in place, we will modify the `jenkins-x.yaml` file, which currently has exactly one line as follows:
@@ -114,7 +114,7 @@ Therefore, we want to inject a timestamp **before** and **after** each of these 
       - name: honeycomb-npm-install-before-timestamp
         sh: echo =================================  $(cat step_start)  =================================
       type: before
-      
+
     - name: npm-install
       pipeline: pullRequest
       stage: build

--- a/content/en/blog/news/jenkinsworld-2019-takeaways.md
+++ b/content/en/blog/news/jenkinsworld-2019-takeaways.md
@@ -10,9 +10,9 @@ slug: "jenkinsworld-2019-takeaways"
 aliases: []
 author: John McGehee
 ---
-Jenkins X was the star of the show at DevOps World | Jenkins World 2019. In this article I will 
+Jenkins X was the star of the show at DevOps World | Jenkins World 2019. In this article I will
 share with you the dozen key things I learned about this exciting new cloud native CI/CD tool.
-Beyond its capabilities as a CI/CD tool, Jenkins X also provides an excellent example of how to architect 
+Beyond its capabilities as a CI/CD tool, Jenkins X also provides an excellent example of how to architect
 a cloud native application on Kubernetes.
 
 Jenkins X is a completely new CI/CD system that shares little but its name with the existing Jenkins. Jenkins X incorporates the best practices from the *State of DevOps* reports and the seminal book, *Accelerate* by [Nicole Forsgren](https://twitter.com/nicolefv), [Jez Humble](https://twitter.com/jezhumble) and [Gene Kim](https://twitter.com/RealGeneKim).
@@ -23,22 +23,22 @@ I attended multiple presentations by [James Strachan](https://twitter.com/jstrac
 
 ## Setting up Kubernetes
 
-[Terraform is recommended](https://cb-technologists.github.io/posts/gitops-series-part-1/) for 
+[Terraform is recommended](https://cb-technologists.github.io/posts/gitops-series-part-1/) for
 setting up the required Kubernetes cluster and storage buckets. As explained below, you may find it
 useful to run `jx boot` from within Terraform.
 
-By default, Terraform stores its state in local file `terraform.tfstate`. In an ephemeral cloud 
-environment, this state gets lost and you would create a new cluster each time you applied 
+By default, Terraform stores its state in local file `terraform.tfstate`. In an ephemeral cloud
+environment, this state gets lost and you would create a new cluster each time you applied
 Terraform. Remedy this by specifying a [Terraform backend](https://www.terraform.io/docs/
-backends/index.html) to store the state in more durable storage like Google Cloud Storage or 
+backends/index.html) to store the state in more durable storage like Google Cloud Storage or
 Amazon S3.
 
 Presenters recommended nginx as an ingress controller and
-[cert-manager](https://cb-technologists.github.io/posts/gitops-series-part-1/) to manage TLS 
+[cert-manager](https://cb-technologists.github.io/posts/gitops-series-part-1/) to manage TLS
 (HTTPS SSL) certificates.
 
 For introspection, navigation and object management of your Kubernetes cluster, try
-[VMWare's Octant UI tool](https://github.com/vmware/octant). It runs on your local client just like 
+[VMWare's Octant UI tool](https://github.com/vmware/octant). It runs on your local client just like
 `kubectl`. An advantage of Octant is that it authenticates the same way as `kubectl`: if `kubectl` works, octant works.
 
 ## Setting up Jenkins X
@@ -48,7 +48,7 @@ For a stable build of Jenkins X, get the
 
 Jenkins X has two modes:
 
-* Static traditional Jenkins master with Jenkins pipelines. Use this if you want to continue 
+* Static traditional Jenkins master with Jenkins pipelines. Use this if you want to continue
   using your existing Jenkinsfiles.
 * Jenkins X pipelines based on [Tekton pipelines](https://github.com/tektoncd/pipeline).
   This is now the default, and is recommended for the long term. This mode is controlled by
@@ -56,36 +56,36 @@ Jenkins X has two modes:
   syntax.
 
 There are two interactive quick start commands. The older and presumably more stable is:
-```
+```sh
 jx create quickstart
 ```
 
 The new way to install, configure and upgrade Jenkins X is:
-```
+```sh
 jx boot
 ```
 
 `jx boot` interactively queries the user for the required setup data, recording the responses in file `jx-requirements.yml`. It is re-entrant so you can run it repeatedly. Running `jx boot` from within Terraform is a useful technique.
 
-Jenkins X evolves quickly, so `jx boot` records the Jenkinx X version to use in field 
-`versionStream` within `jx-requirements.yml`. This establishes the version to use on subsequent 
+Jenkins X evolves quickly, so `jx boot` records the Jenkinx X version to use in field
+`versionStream` within `jx-requirements.yml`. This establishes the version to use on subsequent
 invocations of `jx boot`. Update `versionStream` when you want to start using a newer version of
 Jenkins X.
 
 ## Getting status
 
 Get logs using:
-```
+```sh
 jx get build logs
 ```
 
 Track execution with:
-```
+```sh
 jx get activity
 ```
 
 List preview environments using:
-```
+```sh
 jx get environments
 ```
 
@@ -122,14 +122,14 @@ There are three ways to define a Jenkins X pipeline:
 
 * Automatically via a build pack. The build pack automatically detects the source code language.
 * Specify a build pack and then override portions of it in `jenkins-x.yml`
-* Fully define an entirely new pipeline in `jenkins-x.yml`. This is only useful for a pipeline 
+* Fully define an entirely new pipeline in `jenkins-x.yml`. This is only useful for a pipeline
   that will not be reused. For reusable pipelines, define a build pack.
 
-Build packs are standard, opinionated pipelines for languages. They consist of a predefined 
-sequence of steps that run in a consistent order. They are similar to stages in that they can be 
+Build packs are standard, opinionated pipelines for languages. They consist of a predefined
+sequence of steps that run in a consistent order. They are similar to stages in that they can be
 overridden and extended.
 
-Jenkins X is controlled by a `jenkins-x.yml` file that lives at the root of the Git repository. 
+Jenkins X is controlled by a `jenkins-x.yml` file that lives at the root of the Git repository.
 In `jenkins-x.yml`, you can:
 
 * Override build packs
@@ -150,12 +150,12 @@ in a default pipeline.
 ## Validating syntax and IDE autocompletion
 
 Check your pipelines using:
-```
+```sh
 jx step syntax validate
 ```
 
 Pipelines are usually defined by multiple YAML files. See how they fit together in a single flat pipeline file:
-```
+```sh
 jx step syntax effective
 ```
 
@@ -169,9 +169,9 @@ Accordingly, Jenkins X creates a preview environment for each run of a pull requ
 
 Jenkins X currently uses Prow as a webhook handler and ChatOps engine for pull requests. Importantly, **at this time Prow supports only GitHub.**
 
-Since Jenkins X uses only a small portion of Prow, and since Prow supports only GitHub, the 
-Jenkins X team is developing [Lighthouse](https://github.com/jenkins-x/lighthouse) as a 
-lightweight replacement. In this very experimental webhook handler, the Git provider is factored 
+Since Jenkins X uses only a small portion of Prow, and since Prow supports only GitHub, the
+Jenkins X team is developing [Lighthouse](https://github.com/jenkins-x/lighthouse) as a
+lightweight replacement. In this very experimental webhook handler, the Git provider is factored
 out so that new providers can be easily added.
 
 As an aside, adding a [new Git provider for Lighthouse](https://github.com/jenkins-x/go-scm) would be an excellent way to learn the Go language.

--- a/content/en/blog/news/provision-jx-clusters-terraform.md
+++ b/content/en/blog/news/provision-jx-clusters-terraform.md
@@ -2,7 +2,7 @@
 title: "Managing Jenkins X Kubernetes Clusters Using Infrastructure as Code With Terraform"
 date: 2019-04-03T07:36:00+02:00
 description: >
-    Use Infrastructure as Code to provision Jenkins X clusters. 
+    Use Infrastructure as Code to provision Jenkins X clusters.
 categories: [blog]
 keywords: [terraform,IaC,provisioning,k8s]
 slug: "terraform-jenkins-x"
@@ -23,14 +23,14 @@ CAUTION: Do not make updates to the cluster that require recreating the cluster 
 {{% /alert %}}
 
 # Overview
-Many organizations have adopted DevOps practices in the last few years.  This is valuable as it relates to Jenkins X as we provide a way to manage the Kubernetes clusters  Infrastructure as Code which is one of the core concepts of DevOps practices as it relates to automation.  
+Many organizations have adopted DevOps practices in the last few years.  This is valuable as it relates to Jenkins X as we provide a way to manage the Kubernetes clusters  Infrastructure as Code which is one of the core concepts of DevOps practices as it relates to automation.
 
 Many environments may only allow for creating cloud resources using IaC, therefore we provide you with guidance on how to get started using Terraform to manage your Jekins X clusters.
 
 Our objective is to bring awareness to our Jenkins X users on know that they can manage the cluster changes and version them by placing the Terraform code source control and adopting the typical developer workflow which includes PRs in source control to make infrastructure changes in a controlled manner.
 
 ## Terraform clusters for AWS, GCP and Azure
-Jenkins X supports generating Terraform plans and code for all three leading clouds (AWS, Azure and GCP).  
+Jenkins X supports generating Terraform plans and code for all three leading clouds (AWS, Azure and GCP).
 
 On this post we walk you through the steps for terraforming clusters in GKE.
 
@@ -43,7 +43,7 @@ On this post we walk you through the steps for terraforming clusters in GKE.
 
 To get started, you must have the following items installed on your machine.
 
- - The `jx` CLI installed.  
+ - The `jx` CLI installed.
  - Terraform - can be installed using `brew install terraform`
 - GCP account with proper rights to create resources
 - The Google Cloud CLI `gcloud`
@@ -51,16 +51,16 @@ To get started, you must have the following items installed on your machine.
 
 # Step 1 - Create Terraform Plan
 
-Our first task is to generate the Terraform code for each cluster, we create a Dev, Staging and Production cluster. 
+Our first task is to generate the Terraform code for each cluster, we create a Dev, Staging and Production cluster.
 
-We execute the `jx create terraform -c dev=gke -c stage=gke -c prod=gke`.  
+We execute the `jx create terraform -c dev=gke -c stage=gke -c prod=gke`.
 
-The command generates three different clusters for each environment respectively in GCP.  Other providers supported are  aks, eks. 
+The command generates three different clusters for each environment respectively in GCP.  Other providers supported are  aks, eks.
 
 ## Folder Structure Output
 Running the previous command, outputs the following folder structure wherever we executed the command locally.
 
-```
+```txt
 ├── README.md
 ├── build.sh
 ├── ci-demo-206601-121d21dc79ac.json
@@ -93,7 +93,7 @@ Running the previous command, outputs the following folder structure wherever we
 
 7 directories, 22 files
 ```
-We now have a great code-base to create our clusters on GKE for three different environments. 
+We now have a great code-base to create our clusters on GKE for three different environments.
 
 {{% alert %}}
 NOTE: On this Post, we will only create the Dev Cluster, although the process is the same for creating the other Kubernetes clusters.
@@ -102,23 +102,23 @@ First we need to make sure we have credentials to execute our Terraform code.
 
 # Step 2 - Get GKE Credentials
 
-Jenkins X creates a Service Account (SA) for each cluster. 
+Jenkins X creates a Service Account (SA) for each cluster.
 
 For our dev cluster, it has created the jx-questerring-dev@ci-demo-206601.iam.gserviceaccount.com account.
 
 We need to download the `json` file in order to pass as credentials to our `terraform.tf` file which contains the definition to access the Terraform Backend.
 
 ## Downloading Credentials JSON File
-To download the SA account credentials, go to the GCP Console > IAM &  Admin > Service Accounts.  
+To download the SA account credentials, go to the GCP Console > IAM &  Admin > Service Accounts.
 
-We find the one for our cluster which is named in our case 
+We find the one for our cluster which is named in our case
 as follows: `jx-questerring-dev@ci-demo-206601.iam.gserviceaccount.com`
 
-We click on the file *name*  > *edit*, then click on *create key* in JSON format, download and save in our project folder structure. 
+We click on the file *name*  > *edit*, then click on *create key* in JSON format, download and save in our project folder structure.
 
 We now add a reference within the `terraform.tf` as shown below.
 
-```
+```tf
 terraform {
     required_version = ">= 0.11.0"
     backend "gcs" {
@@ -134,8 +134,8 @@ Notice that we added the `credentials` portion and point to the credentials `jso
 # Step 3 - Initiate Terraform Backend
 We are now ready to initiate Terraform backend.  Terraform backends are used to save the Terraform State remotely.  This is great for when a team needs to collaborate on making infrastructure changes, because the Terraform State is stored in the GCP Bucket that was also created when we executed our initial command to create the cluster.
 
-```
-$ terraform init                                                                                                               
+```tf
+$ terraform init
 Initializing the backend...
 
 Successfully configured the backend "gcs"! Terraform will automatically
@@ -155,8 +155,8 @@ We now can execute a `terraform plan` and see what will be created.  At this poi
 
 For example, you may have an existing network that you wish to deploy the cluster in.  You may also wish to enable the an add-on, or you can specify the cluster_ipv4_cidr_block and many other things (see https://www.terraform.io/docs/providers/google/r/container_cluster.html) for details.
 
-```
-$ terraform plan                                                                                 
+```sh
+$ terraform plan
 
 Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
@@ -257,7 +257,7 @@ can't guarantee that exactly these actions will be performed if
 # Step 5 - Create Cluster Using Terraform Apply
 Now that we've seen what will be created and using the default terraform code generated, let us create said resources!
 
-```
+```sh
 $ terraform apply
 .....trimmed for brevity
 Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
@@ -273,18 +273,18 @@ The outcome shows some key information, like the *cluster_endpoint* and the *clu
 
 Let us access the cluster using kubectl.  In order to do that, we need to get credentials.  We execute the following command (which you can get from the UI on GCP right from the cluster connect window)
 
-```
-$ gcloud container clusters get-credentials questerring-dev --zone us-west1-a --project ci-demo-206601 
-                        
+```sh
+$ gcloud container clusters get-credentials questerring-dev --zone us-west1-a --project ci-demo-206601
+
 Fetching cluster endpoint and auth data.
 kubeconfig entry generated for questerring-dev.
 ```
-This has effectively modified our `kubeconfig` file and we now have a new context.  
+This has effectively modified our `kubeconfig` file and we now have a new context.
 
 Executing the following command, we see our new cluster (in bold)
 
-```
-$ jx context                                                                                                                      
+```sh
+$ jx context
 BigDaddyO
 arn:aws:eks:us-west-2:653931956080:cluster/jxcluster
 gke_ci-demo-206601_europe-west1-b_sirjenkinsgke
@@ -316,7 +316,7 @@ We are going to modify the cluster and add an add-on for the Dashboard which is 
 
 To do that we change the following within the cluster declaration in main.tf and add the following (in bold):
 
-```
+```tf
 resource "google_container_cluster" "jx-cluster" {
     name                     = "${var.cluster_name}"
     description              = "jx k8s cluster provisioned and managed via Terraform."
@@ -349,8 +349,8 @@ resource "google_container_cluster" "jx-cluster" {
 
 Then we run the terraform plan, output shows a change to the cluster as expected.
 
-```
-terraform plan                                                                                                             
+```sh
+$ terraform plan
 
 Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
@@ -387,7 +387,7 @@ NOTE: This dashboard is deprecated, and we are only showing you in the context o
 {{ /alert }}
 
 ### Get Access token
-```
+```sh
 gcloud config config-helper --format=json | jq -r '.credential.access_token'
 ```
 
@@ -400,7 +400,7 @@ http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-da
 Paste the token and now you should be able to access the now deprecated dashboard via the browser.
 
 # Conclusion
-We walked through how to create your initial Terraform code and structure, created the Dev cluster and modified it by specifying an add-on to include in our cluster.  
+We walked through how to create your initial Terraform code and structure, created the Dev cluster and modified it by specifying an add-on to include in our cluster.
 
 Please keep in mind, that once *GitOps* feature in Jenkins X is available, we recommend you manage the platform in that manner.  Documentation, tutorials and presentations on that topic will be coming soon!
 

--- a/content/en/docs/concepts/features.md
+++ b/content/en/docs/concepts/features.md
@@ -27,7 +27,7 @@ With Jenkins X each _team_ gets its own Environments. By default Jenkins X creat
 
 There is also the `Dev` environment which is where tools like Jenkins, Nexus or Prow are installed and where CI/CD pipelines run.
 
-We use GitOps to manage the configuration and version of the kubernetes resources which are deployed to each environment. So each Environment has its own git repository that contains all the Helm Charts, their versions and the configuration for the applications be run in the environment. 
+We use GitOps to manage the configuration and version of the kubernetes resources which are deployed to each environment. So each Environment has its own git repository that contains all the Helm Charts, their versions and the configuration for the applications be run in the environment.
 
 An Environment maps to a namespace in a Kubernetes cluster. When Pull Requests are merged into the environments git repository the pipeline runs for the environment which then applies the helm charts in git to the environments namespace.
 
@@ -37,7 +37,7 @@ This means both developers and operations can use the same git repository to man
 
 ## Teams
 
-A Team in Jenkins X is represented by an install of Jenkins X in a separate namespace. 
+A Team in Jenkins X is represented by an install of Jenkins X in a separate namespace.
 
 You can install Jenkins X into different namespaces in the same cluster if you wish using the `--namespace` command line argument in [jx create cluster](/commands/jx_create_cluster/) or [jx install](/commands/jx_install/). Note that to support multiple installs of Jenkins X in the same cluster you need to [avoid Tiller if you are using helm 2.x](/news/helm-without-tiller/).
 
@@ -45,14 +45,14 @@ You can also use the [jx create team](/commands/jx_create_team/) CLI which creat
 
 See the [configuration guide](/docs/managing-jx/common-tasks/config/) for more details on how to share resources like Nexus across Teams.
 
- 
+
 ## Promotion
 
 Promotion is implemented with GitOps by generating a pull request on the Environment's git repository  so that all changes go through git for audit, approval and so that any change is easy to revert.
 
 When a new change to an environments git repository is merged to master, the pipeline for the environment triggers which applies any changes to the resources via helm - using the source code from the git repository.
 
-The CD Pipelines of Jenkins X automate the promotion of version changes through each Environment which is configured with a _promotion strategy_ property of `Auto`. By default the `Staging` environment uses automatic promotion and the `Production` environment uses `Manual` promotion. 
+The CD Pipelines of Jenkins X automate the promotion of version changes through each Environment which is configured with a _promotion strategy_ property of `Auto`. By default the `Staging` environment uses automatic promotion and the `Production` environment uses `Manual` promotion.
 
 To manually promote a version of an application to an environment you can use [jx promote](/developing/promote) command.
 
@@ -63,13 +63,13 @@ To manually promote a version of an application to an environment you can use [j
 Jenkins X lets you spin up Preview Environments for your Pull Requests so you can get fast feedback before changes are merged to master. This gives you faster feedback for your changes before they are merged and released and allows you to avoid having human approval inside your release pipeline to speed up delivery of changes merged to master.
 
 When the Preview Environment is up and running Jenkins X will comment on your Pull Request with a link so in one click your team members can try out the preview!
- 
+
 <img src="/images/pr-comment.png" class="img-thumbnail">
 
 
 ## Feedback
 
-As you can see above Jenkins X automatically comments on your Pull Requests when using Preview Environments. 
+As you can see above Jenkins X automatically comments on your Pull Requests when using Preview Environments.
 
 If the commit comments reference issues (e.g. via the text `fixes #123`) then Jenkins X pipelines will generate release notes like those of [the jx releases](https://github.com/jenkins-x/jx/releases).
 
@@ -88,6 +88,6 @@ Some of these applications are baked in; like: Nexus, ChartMuseum, Monocular.  O
 
 To install an addon then use the [jx create addon](/commands/jx_create_addon/) command. e.g.
 
-```
+```sh
 jx create addon grafana
 ```

--- a/content/en/docs/concepts/jenkins-x-pipelines.md
+++ b/content/en/docs/concepts/jenkins-x-pipelines.md
@@ -11,33 +11,33 @@ aliases:
 weight: 40
 ---
 
-We [recently announced](/news/jenkins-x-next-gen-pipeline-engine) that we are introducing **Jenkins X Pipelines**, a new serverless pipeline execution engine based on the [Tekton Pipelines](https://tekton.dev/) open source project. 
+We [recently announced](/news/jenkins-x-next-gen-pipeline-engine) that we are introducing **Jenkins X Pipelines**, a new serverless pipeline execution engine based on the [Tekton Pipelines](https://tekton.dev/) open source project.
 
 Tekton has been designed to be a modern cloud native solution for running pipelines.
 
-The work here is still experimental but we'd love feedback and help from the community to drive it forward.  
+The work here is still experimental but we'd love feedback and help from the community to drive it forward.
 
 ## Trying Jenkins X Pipelines
 
 Right now to enable a Tekton based install you can create a new cluster using `jx` along with these flags:
 
-```
-jx create cluster gke --tekton 
+```sh
+jx create cluster gke --tekton
 ```
 
 Or if you want to go all in on the next generation of Jenkins X with built-in GitOps for your development environment, using Tekton and using Vault for storage of Secrets then use the following (only works on GCP and AWS right now):
 
-```
+```sh
 jx create cluster gke --ng
 ```
 
 The general developer experience, CLI and IDE plugins should work as before - but using [Tekton Pipelines](https://tekton.dev/) Custom Resources under the covers instead of creating a Jenkins Server per team!
 
 ## Using a quickstart
- 
+
 Once your cluster is started you can create a new quickstart, we've been using the NodeJS one reliably.
 
-```
+```sh
 jx create quickstart
 ```
 
@@ -51,12 +51,12 @@ However it's still reusing the same reusable and composable build packs under th
 
 One thing you will notice is that with Jenkins X Pipelines we don't need to copy/paste a large `Jenkinsfile` into each application's git repository; usually the generated `jenkins-x.yml` file is small, like this:
 
-```yaml 
+```yaml
 buildPack: maven
 ```
 
 That's it! What that basically means is at runtime the Jenkins X Pipeline will use the [build packs](/docs/managing-jx/common-tasks/build-packs/) to generate the actual Tekton Pipeline.
- 
+
 ## Customizing the Pipelines
 
 Having automated [build packs](/docs/managing-jx/common-tasks/build-packs/) to do all of your CI+CD is pretty awesome - as most of the time your microservices will all be compiled, tested, packaged, released and promoted in the same way. CI+CD is often undifferentiated heavy lifting we should just automate!
@@ -76,11 +76,11 @@ For a quick way to add a new step into a pipeline life cycle you can use the [jx
 
 You can also add or override an environment variable in your pipeline via the [jx create variable](/commands/jx_create_variable/) command
 
-## Editing in VS Code 
+## Editing in VS Code
 
-If you are using [VS Code](https://code.visualstudio.com/) we recommend you install the [YAML Language Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) from Red Hat. 
+If you are using [VS Code](https://code.visualstudio.com/) we recommend you install the [YAML Language Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) from Red Hat.
 
-This extension lets you edit YAML files with optional JSON Schema validation. 
+This extension lets you edit YAML files with optional JSON Schema validation.
 
 Jenkins X's JSON Schema is already registered with [schemastore.org](http://schemastore.org/json/) so editing your `jenkins-x.yml` file in VS Code will include smart completion and validation!
 
@@ -122,4 +122,4 @@ The following environment variables are available for use in a step in Jenkins X
 | PULL_BASE_SHA | the git SHA being built |
 | PULL_NUMBER | for PRs this will be the number without the `PR-` prefix
 | PULL_REFS | for batch merging all the git refs |
- 
+

--- a/content/en/docs/concepts/version-stream.md
+++ b/content/en/docs/concepts/version-stream.md
@@ -28,9 +28,9 @@ The [jx](https://github.com/jenkins-x/jx) release now defaults to being released
 
 We use GitOps and CI/CD to manage the Version Stream.
 
-As new packages or charts are released we generate Pull Requests on the [jenkins-x/jenkins-x-versions](https://github.com/jenkins-x/jenkins-x-versions) git repository. We then trigger our [BDD tests](https://github.com/jenkins-x/bdd-jx) via [jx step bdd](/commands/jx_step_bdd/) and verify the new chart/package version works before merging changes. Currently we manually trigger the BDD tests via a comment of `/test this` - but we hope to move to periodic triggering of the BDD tests (e.g. once per day). 
+As new packages or charts are released we generate Pull Requests on the [jenkins-x/jenkins-x-versions](https://github.com/jenkins-x/jenkins-x-versions) git repository. We then trigger our [BDD tests](https://github.com/jenkins-x/bdd-jx) via [jx step bdd](/commands/jx_step_bdd/) and verify the new chart/package version works before merging changes. Currently we manually trigger the BDD tests via a comment of `/test this` - but we hope to move to periodic triggering of the BDD tests (e.g. once per day).
 
-Pull Request approvers can also choose to run their own manual tests on Pull Requests if they want. 
+Pull Request approvers can also choose to run their own manual tests on Pull Requests if they want.
 
 Upon the successful completion of all BDD tests executed on the PR it will merge the change and execute an update to all jx dependencies (homebrew-jx, jx-docs, jx-tutorial and dev-env-base).
 
@@ -40,8 +40,7 @@ We have a simple CLI command [jx step create version pr](/commands/jx_step_creat
 
 If you are the maintainer of an upstream chart that is used by Jenkins X it would be awesome to add this command at the end of your release pipeline to generate a Pull Request for us to upgrade Jenkins X to use your new release (after the BDD tests have run to verify things still work):
 
-```shell 
-
+```sh
 jx step create version pr -n mychartName -v 1.2.3
 ```
 
@@ -54,8 +53,7 @@ Its not always easy/possible to update upstream pipelines to push version change
 e.g. to upgrade the versions of all the `jenkins-x` maintained charts you can run this command:
 
 
-```shell 
-
+```sh
 jx step create version pr -f "jenkins-x/*"
 ```
 
@@ -65,7 +63,7 @@ From a git clone of master or a Pull Request you can run the BDD tests against t
 
 e.g. you can run the BDD tests yourself via...
 
-```shell 
+```sh
 git clone https://github.com/jenkins-x/jenkins-x-versions.git
 
 # env vars for the git / jenkins secrets

--- a/content/en/docs/contributing/addons/_index.md
+++ b/content/en/docs/contributing/addons/_index.md
@@ -75,8 +75,8 @@ via client libraries for different platforms. Currently we offer clients for:
 
 [jx](https://github.com/jenkins-x/jx) contains many useful functions and is documented on [godoc.org](https://godoc.org/github.com/jenkins-x/jx). The easiest way to consume it is is as a go module:
 
-```bash
-$ go get github.com/jenkins-x/jx
+```sh
+go get github.com/jenkins-x/jx
 ```
 ## `jx` app CLI Commands
 

--- a/content/en/docs/contributing/addons/plugins.md
+++ b/content/en/docs/contributing/addons/plugins.md
@@ -5,8 +5,8 @@ description: Binary Plugins for the Jenkins X CLI
 weight: 10
 ---
 
-This guide shows you how to write plugins for the `jx` CLI. Plugins extend the `jx` CLI with new sub-commands allowing for new 
-features not included in Jenkins X. `jx` plugins can be managed by Jenkins X meaning neither the plugin developer nor 
+This guide shows you how to write plugins for the `jx` CLI. Plugins extend the `jx` CLI with new sub-commands allowing for new
+features not included in Jenkins X. `jx` plugins can be managed by Jenkins X meaning neither the plugin developer nor
 the plugin user has to worry about how to install the plugin onto the user's computer.
 
 You might want to write a plugin for the `jx` CLI if you developed some new functionality for Jenkins X and wanted to provide a
@@ -23,7 +23,7 @@ You can write a plugin in any programming language or script that allows you to 
 
 There is no plugin installation or pre-loading required. Plugin executables receive the inherited environment from the
  `jx` binary.
- 
+
 ### Example plugin
 
 Here is a simple plugin that simply outputs a log statement.
@@ -41,27 +41,32 @@ func main() {
 	os.Exit(0)
 }
 ```
- 
-We strongly recommend using Go and the [Cobra CLI framework](https://github.com/spf13/cobra). This allows you to easily 
-build a well structured plugin with subcommands and argument handling.  
 
-We [plan](https://github.com/jenkins-x/jx/issues/2832) to build a quickstart and build pack that allows you to 
+We strongly recommend using Go and the [Cobra CLI framework](https://github.com/spf13/cobra). This allows you to easily
+build a well structured plugin with subcommands and argument handling.
+
+We [plan](https://github.com/jenkins-x/jx/issues/2832) to build a quickstart and build pack that allows you to
 quickly create a new Cobra based plugin.
 
 ### Using the plugin
 
 1. Build a binary
-  
-    ```$ go build -o jx-brie brie.go```
-2. Add it to your path
 
-    ```$ sudo mv ./jx-brie /usr/local/bin```
+```sh
+go build -o jx-brie brie.go
+```
+
+2. Add it to your path
+```sh
+sudo mv ./jx-brie /usr/local/bin
+```
+
 3. You can now use the plugin
 
-    ```
+```sh
 $ jx brie
 Have some tasty brie
-    ```
+```
 
 ## Plugin Management
 
@@ -69,7 +74,7 @@ Whilst being able to run a plugin is useful you'll normally want to make it avai
 
 Jenkins X provides binary plugin management via the `plugin` custom resource.
 
-TODO 
+TODO
 
 ## Distributing your plugin using Apps
 

--- a/content/en/docs/contributing/addons/worked-example.md
+++ b/content/en/docs/contributing/addons/worked-example.md
@@ -46,7 +46,7 @@ We'll start by creating a sample Java project which will run some tests.
 
 1. Create the file `src/test/java/jenkinsx/example/springboot/WelcomeControllerTest.java`.
 1. Copy and paste this code into the `WelcomeControllerTest`
-   
+
     ```java
     package jenkinsx.example.springboot;
 
@@ -189,8 +189,8 @@ We need a place to store the reports. A simple Go program will suffice for now.
     }
     ```
 
-    This code will create an HTTP server that listens on two ports. It listens on 8080 to serve files from the `/reports` directory, and listens on 8081 for file uploads (using the URL path as the path as the location under `/reports` to store the file). By listening on different ports for download and upload we can easily expose the downloads service outside the cluster, but restrict the uploads service to inside the cluster meaning we have no need to secure the transport. 
-    
+    This code will create an HTTP server that listens on two ports. It listens on 8080 to serve files from the `/reports` directory, and listens on 8081 for file uploads (using the URL path as the path as the location under `/reports` to store the file). By listening on different ports for download and upload we can easily expose the downloads service outside the cluster, but restrict the uploads service to inside the cluster meaning we have no need to secure the transport.
+
     We'll add authentication to the upload endpoint at a later point.
 1. We need to store the reports somewhere, and in Kubernetes this means using a volume. Add this snippet to the bottom of `charts/jenkins-x-reports/templates/deployment.yaml`:
 
@@ -217,7 +217,7 @@ We need a place to store the reports. A simple Go program will suffice for now.
     You'll notice that we've used `emptyDir{}` to store the reports - this is transient and reports will be lost when the pod dies. We'll replace this with a persistent volume later.
 1. Modify the `Dockerfile` to expose port `8081` as well by adding the line `EXPOSE 8081` just after `EXPOSE 8080`.
 2. Modify `charts/jenkins-x-reports/values.yaml` and add the values for the upload service just after the existing service:
-   
+
     ```yaml
     serviceUpload:
       name: jenkins-x-reports-upload
@@ -229,7 +229,7 @@ We need a place to store the reports. A simple Go program will suffice for now.
     Notice how we've given it a unique name, set the internal port correctly and removed the annotations that instruct Jenkins X to expose the service outside the cluster.
 
     We now need to create a template for these values. Add the file `charts/jenkins-x-reports/templates/service-upload.yaml`:
-   
+
       ```
       apiVersion: v1
       kind: Service
@@ -268,7 +268,7 @@ We need a place to store the reports. A simple Go program will suffice for now.
 1. Validate you can upload and download files. In the DevPod for the sample app run `curl -F upload=@target/site/surefire-report.html http://jenkins-x-reports-upload.jx-staging/test/1` and then validate that the file is there by running `curl http://jenkins-x-reports.jx-staging/test/1`.
 2. Promote the app to production using `jx promote -a jenkins-x-reports -e production -v 0.0.1` (assuming you are still on your first version of the app)
 1. To POST all the JUnit artifacts to the reports server use this script
-   
+
     ```bash
     #!/bin/bash
 
@@ -352,7 +352,7 @@ We'll use one `ConfigMap` per app, and we'll use a standard naming pattern so th
 
 ### Visualize the test results
 
-We'll use Kibana and ElasticSearch to create dashboards to visualize the test results. 
+We'll use Kibana and ElasticSearch to create dashboards to visualize the test results.
 
 1. Install ElasticSearch by running `helm install --name jenkins-x-reports-elasticsearch incubator/elasticsearch`
 2. Install Kibana by running `helm install stable/kibana --name=jenkins-x-reports-kibana --set service.annotations."fabric8\.io/expose"=true --set files."kibana\.yml"."elasticsearch\.url"=http://jenkins-x-reports-elasticsearch-client:9200 --set  && jx upgrade ingress`.
@@ -362,11 +362,11 @@ We'll use Kibana and ElasticSearch to create dashboards to visualize the test re
 3. Create a mapping for the JUnit XML format in Kibana by pasting this code into the Kibana console:
 
     ```json
-    PUT tests 
+    PUT tests
     {
         "mappings": {
-          "junit": { 
-            "properties": { 
+          "junit": {
+            "properties": {
             "errors": { "type": "integer" },
             "failures": { "type": "integer" },
             "name": { "type": "keyword" },
@@ -385,7 +385,7 @@ We'll use Kibana and ElasticSearch to create dashboards to visualize the test re
     }
     ```
 
-1. An initial client for sending data to Kibana is available at (https://github.com/pmuir/junit-runner). Download it and get it building. 
+1. An initial client for sending data to Kibana is available at (https://github.com/pmuir/junit-runner). Download it and get it building.
 As we start to convert the functionality we've built so far to a Jenkins X extension, we'll move the scripted code we've written so far into this Go program. For now, we can just use the current version.
 1. Add this function to `junit.sh`:
 
@@ -491,7 +491,7 @@ Let's open that project up, and move the code which transforms the JUnit XML and
       "github.com/clbanning/mxj"
       "github.com/clbanning/mxj/x2j"
       json2 "encoding/json"
-    ```   
+    ```
 
     And then add this by running `dep init` which will detect our dependency and set it up properly.
 4. We'll also need to call it for each JUnit XML file we receive. And only for JUnit files. We can use the HTTP headers for this:
@@ -517,7 +517,7 @@ Just above where we write the success message to the HTTP stream, add this code 
     If you are wondering why we use `X-Content-Type` it is to avoid breaking the multipart form upload for the file!
 6. And of course we need to remove `junit-runner`. Delete the `dashboard()` function and remove the call to it from `upload()`.
 7. Now, let's clean things up a bit more by moving the code creating the configmap from the `junit.sh` script into the `jenkins-x-reports` code. First, we need to add a dependency on kubernetes-client to our code. Edit `Gopkg.toml` and add:
-    
+
     ```toml
     [[constraint]]
       name = "k8s.io/api"
@@ -637,11 +637,11 @@ Just above where we write the success message to the HTTP stream, add this code 
     if version == "" {
       renderError(w, "MUST_PROVIDE_X-VERSION_HEADER", http.StatusInternalServerError)
       log.Println("No X-VERSION HEADER provided")
-    }	
+    }
     ```
 
     And add just above the success message:
-    
+
     ```go
     cm, err := getOrCreateConfigMap(org, app, client)
 		if err != nil {
@@ -678,4 +678,4 @@ At this point the JX team have also learned that we want to build some additiona
 * `jx step collect` for collecting build artifact that will run even if the build fails
   * Add URLs to the `PipelineActivity` CRD
 
-TODO complete the guide 
+TODO complete the guide

--- a/content/en/docs/contributing/code/_index.md
+++ b/content/en/docs/contributing/code/_index.md
@@ -29,7 +29,7 @@ To contribute to Jenkins X jx binary, you will need:
  - [Go](https://golang.org/) `1.11.4`, with support for compiling to `linux/amd64`
  - [pre-commit](https://pre-commit.com/#install) - once installed, ensure you're at the root of the repository which contains a `.pre-commit-config.yaml` configuration file, then:
 
-```bash
+```sh
 pre-commit install
 ```
 
@@ -45,8 +45,8 @@ If you are having trouble following the installation guides for go, check out [G
 
 If you are a macOS user and have [Homebrew](https://brew.sh/) installed on your machine, installing Go is as simple as the following command:
 
-```shell
-$ brew install go
+```sh
+brew install go
 ```
 
 ### Install Go via GVM
@@ -64,7 +64,7 @@ Simply install the latest version by downloading the [installer](https://golang.
 
 If you have used an older version of go you may have old versions of go modules. So its good to run this command to clear your cache if you are having go build issues:
 
-```shell
+```sh
 go clean -modcache
 ```
 
@@ -72,13 +72,13 @@ go clean -modcache
 
 Once you're finished installing Go, let's confirm everything is working correctly. Open a terminal - or command line under Windows - and type the following:
 
-```shell
-$ go version
+```sh
+go version
 ```
 
 You should see something similar to the following written to the console (on macOS). Note that the version here reflects the most recent version of Go as of the last update for this page:
 
-```
+```sh
 go version go1.11 darwin/amd64
 ```
 
@@ -86,7 +86,7 @@ Next, make sure that you set up your `GOPATH` [as described in the installation 
 
 You can print the `GOPATH` with `echo $GOPATH`. You should see a non-empty string containing a valid path to your Go workspace; .e.g.:
 
-```shell
+```sh
 $ echo $GOPATH
 /Users/<yourusername>/Code/go
 ```
@@ -111,14 +111,14 @@ Hub is a great tool for working with GitHub. The main site for it is [hub.github
 
 On a Mac, you can install [Hub](https://github.com/github/hub) using [Homebrew](https://brew.sh):
 
-```shell
-$ brew install hub
+```sh
+brew install hub
 ```
 
 Now we'll create an [alias in Bash](http://tldp.org/LDP/abs/html/aliases.html) so that typing `git` actually runs `Hub`:
 
-```shell
-$ echo "alias git='hub'" >> ~/.bash_profile
+```sh
+echo "alias git='hub'" >> ~/.bash_profile
 ```
 
 ## Create a GitHub Account
@@ -147,29 +147,29 @@ Now open your fork repository on GitHub and copy the remote url of your fork. Yo
 
 Then go back to your terminal and clone your fork locally. Since jx is a Go package, it should be located at `$GOPATH/src/github.com/jenkins-x/jx`.
 
-```shell
-$ mkdir -p $GOPATH/src/github.com/jenkins-x
-$ cd $GOPATH/src/github.com/jenkins-x
-$ git clone git@github.com:<YOUR_USERNAME>/jx.git
-$ cd jx
+```sh
+mkdir -p $GOPATH/src/github.com/jenkins-x
+cd $GOPATH/src/github.com/jenkins-x
+git clone git@github.com:<YOUR_USERNAME>/jx.git
+cd jx
 ```
 
 Add the conventional upstream `git` remote in order to fetch changes from jx's main master
 branch and to create pull requests:
 
-```shell
-$ git remote add upstream https://github.com/jenkins-x/jx.git
+```sh
+git remote add upstream https://github.com/jenkins-x/jx.git
 ```
 
 Let's check if everything went right by listing all known remotes:
 
-```shell
-$ git remote -v
+```sh
+git remote -v
 ```
 
 The output should look similar to:
 
-```
+```sh
 origin    git@github.com:<YOUR_USERNAME>/jx.git (fetch)
 origin    git@github.com:<YOUR_USERNAME>/jx.git (push)
 upstream  https://github.com/jenkins-x/jx.git (fetch)
@@ -180,7 +180,7 @@ upstream  https://github.com/jenkins-x/jx.git (push)
 
 Alternatively, you can use the Git wrapper Hub. Hub makes forking a repository easy:
 
-```
+```sh
 hub fork
 ```
 
@@ -192,16 +192,16 @@ That command will log in to GitHub using your account, create a fork of the repo
 
 First, ensure that your local repository is up-to-date with the latest version of jx. More details on [GitHub help](https://help.github.com/articles/syncing-a-fork/)
 
-```shell
-$ git fetch upstream
-$ git checkout master
-$ git merge upstream/master
+```sh
+git fetch upstream
+git checkout master
+git merge upstream/master
 ```
 
 Now you can create a new branch for your change:
 
-```shell
-$ git checkout -b <BRANCH-NAME>
+```sh
+git checkout -b <BRANCH-NAME>
 ```
 
 You can check on which branch your are with `git branch`. You should see a list of all local branches. The current branch is indicated with a little asterisk.
@@ -220,8 +220,8 @@ Bear in mind when developing that the code can (and will) run on different archi
 
 To push our commits to the fork on GitHub you need to specify a destination. A destination is defined by the remote and a branch name. Earlier, the remote url of our fork was given the default name of `origin`. The branch should be given the same name as our local one. This makes it easy to identify corresponding branches.
 
-```shell
-$ git push --set-upstream origin <BRANCH-NAME>
+```sh
+git push --set-upstream origin <BRANCH-NAME>
 ```
 
 Now Git knows the destination. Next time when you to push commits you just need to enter `git push`.
@@ -232,8 +232,8 @@ With the prerequisites installed and your fork of jx cloned, you can make change
 
 Run `make` to build the `jx` binaries:
 
-```shell
-$ make build
+```sh
+make build
 ```
 See below to get some advises on how to [test](#testing) and [debug](#debugging).
 
@@ -245,13 +245,13 @@ This is a bit more advanced but required to ensure a proper Git history of Jenki
 
 Let's take an example.
 
-```shell
-$ git rebase --interactive @~3
+```sh
+git rebase --interactive @~3
 ```
 
 The `3` at the end of the command represents the number of commits that should be modified. An editor should open and present a list of last three commit messages:
 
-```
+```sh
 pick 911c35b Add "How to contribute to Jenkins X" tutorial
 pick 33c8973 Begin workflow
 pick 3502f2e Refactoring and typo fixes
@@ -261,7 +261,7 @@ In the case above we should merge the last 2 commits in the commit of this tutor
 
 All operations are written before the commit message. Replace `pick` with an operation. In this case `squash` or `s` for short:
 
-```
+```sh
 pick 911c35b Add "How to contribute to Jenkins X" tutorial
 squash 33c8973 Begin workflow
 squash 3502f2e Refactoring and typo fixes
@@ -271,7 +271,7 @@ We also want to rewrite the commits message of the third last commit. We forgot 
 
 You should end up with a similar setup:
 
-```
+```sh
 reword 911c35b Add "How to contribute to Jenkins X" tutorial
 squash 33c8973 Begin workflow
 squash 3502f2e Refactoring and typo fixes
@@ -281,7 +281,7 @@ Close the editor. It should open again with a new tab. A text is instructing you
 
 A last time a new tab opens. Enter a new commit message and save again. Your terminal should contain a status message. Hopefully this one:
 
-```
+```sh
 Successfully rebased and updated refs/heads/<BRANCH-NAME>.
 ```
 
@@ -289,18 +289,17 @@ Check the commit log if everything looks as expected. Should an error occur you 
 
 In case you already pushed your work to your fork, you need to make a force push
 
-```shell
-$ git push --force
+```sh
+git push --force
 ```
 Last step, to ensure that your change would not conflict with other changes done in parallel by other contributors, you need to rebase your work on the latest changes done on jx master branch. Simply:
 
-```shell
-$ git checkout master #Move to local master branch
-$ git fetch upstream #Retrieve change from jx master bracnch
-$ git merge upstream/master #Merge the change into your local master
-$ git checkout <BRANCH-NAME> #Move back to your local branch where you did your development
-$ git rebase master
-
+```sh
+git checkout master #Move to local master branch
+git fetch upstream #Retrieve change from jx master bracnch
+git merge upstream/master #Merge the change into your local master
+git checkout <BRANCH-NAME> #Move back to your local branch where you did your development
+git rebase master
 ```
 Handle any conflicts and make sure your code builds and all tests pass. Then force push your branch to your remote.
 
@@ -350,9 +349,9 @@ good guide from GitHub:
 3. Next, tell [tell GitHub about your key so that it can verify your commits](https://help.github.com/en/articles/adding-a-new-gpg-key-to-your-github-account)
 4. Now, configure git to always use sign commits by running
 
-    ```bash
-    $ git config --global user.signingkey <key id>
-    ```
+```sh
+git config --global user.signingkey <key id>
+```
 
    The process to find the key id is described in [https://help.github.com/en/articles/checking-for-existing-gpg-keys](https://help.github.com/en/articles/checking-for-existing-gpg-keys)
 
@@ -421,23 +420,23 @@ The jx test suite is divided into three sections:
  - Integration tests
 
 To run the standard test suite:
-```shell
-$ make test
+```sh
+make test
 ```
 
 To run the standard test suite including slow running tests:
-```shell
-$ make test-slow
+```sh
+make test-slow
 ```
 
 To run all tests including integration tests (NOTE These tests are not encapsulated):
-```shell
-$ make test-slow-integration
+```sh
+make test-slow-integration
 ```
 
 To get a nice HTML report on the tests:
-```shell
-$ make test-report-html
+```sh
+make test-report-html
 ```
 
 ### Writing tests
@@ -500,12 +499,12 @@ type CommandInterface interface {
 In the example you can see that we pass the generator to use: `pegomock generate` the package path name: `github.com/jenkins-x/jx/pkg/util` the name of the interface: `CommandInterface` and finally an output directive to write the generated file to a mock sub-folder. To keep things nice and tidy it's best to write each mocked interface to a separate file in this folder. So in this case: `-o mocks/command_interface.go`
 
 Now simply run:
-```shell
-$ go generate ./...
+```sh
+go generate ./...
 ```
 or
-```shell
-$ make generate-mocks
+```sh
+make generate-mocks
 ```
 
 You now have a mock to test your new interface!
@@ -551,7 +550,7 @@ Now when we can set up our  test using the mock interface and make assertions as
 
 Lots of the test have debug output to try figure out when things fail. You can enable verbose debug logging for tests via:
 
-```shell
+```sh
 export JX_TEST_DEBUG=true
 ```
 
@@ -561,13 +560,13 @@ First you need to [install Delve](https://github.com/derekparker/delve/blob/mast
 
 Then build a version of `jx` that is optimised for debugging
 
-```shell
+```sh
 DEBUG=on make
 ```
 
 Then you should be able to run a debug version of a jx command:
 
-```shell
+```sh
 dlv --listen=:2345 --headless=true --api-version=2 exec ./build/jx -- some arguments
 ```
 
@@ -580,7 +579,7 @@ If you want to debug using `jx` with `stdin` to test out terminal interaction, y
 1. Find the `pid` of the jx command via something like `ps -elaf | grep jx`
 2. Start Delve, attaching to the pid:
 
-	```shell
+	```sh
 	dlv --listen=:2345 --headless=true --api-version=2 attach SomePID
 	```
 
@@ -588,14 +587,14 @@ If you want to debug using `jx` with `stdin` to test out terminal interaction, y
 
 You can run a single unit test via:
 
-```shell
+```sh
 export TEST="TestSomething"
 make test1
 ```
 
 You can then start a Delve debug session on a unit test via:
 
-```shell
+```sh
 export TEST="TestSomething"
 make debugtest1
 ```
@@ -620,7 +619,7 @@ In some cases it can be useful to see the REST API calls made to the Kubernetes 
 You can enable trace by setting the environment variable `TRACE_KUBE_API` to the value "on" or "1".
 For example:
 
-```bash
+```sh
 TRACE_KUBE_API=on jx get apps
 ```
 

--- a/content/en/docs/contributing/code/builder-images.md
+++ b/content/en/docs/contributing/code/builder-images.md
@@ -89,7 +89,7 @@ Once your files are in place, and you have verified locally that your image buil
 The `update-bot.sh` script is used to create a PR that includes all the updated builder images. Edit the file (it's in the root of the `jenkins-x-builders` repo) and add the appropriate argument to this existing command
 :
 
-```
+```sh
 jx step create pr chart --name gcr.io/jenkinsxio/builder-ruby --name gcr.io/jenkinsxio/builder-swift \
   --name gcr.io/jenkinsxio/builder-dlang --name gcr.io/jenkinsxio/builder-go --name gcr.io/jenkinsxio/builder-go-maven \
   --name gcr.io/jenkinsxio/builder-gradle --name gcr.io/jenkinsxio/builder-gradle4 --name gcr.io/jenkinsxio/builder-gradle5 \

--- a/content/en/docs/contributing/code/triage.md
+++ b/content/en/docs/contributing/code/triage.md
@@ -16,7 +16,7 @@ For a full list of available labels please see https://github.com/jenkins-x/jx/l
 When triaging an issue, someone from the Jenkins X team will assign labels to describe the __area__ and __kind__ of issue.  Where possible they will also add a priority however these are subject to change after further analysis or wider visibility.
 
 Labels are added via the prow [label](https://prow.k8s.io/plugins) plugin using GitHub comments.  For example:
-```
+```text
 /kind bug
 /area prow
 /priority important-soon

--- a/content/en/docs/contributing/documentation/_index.md
+++ b/content/en/docs/contributing/documentation/_index.md
@@ -68,7 +68,7 @@ Now open your fork repository on GitHub and copy the remote url of your fork. Yo
 
 Then go back to your terminal, `cd` to where you would like to place your local copy of the `jx-docs` repo, and then clone your fork.
 
-```shell
+```sh
 git clone --recurse-submodules --depth 1 git@github.com:<YOUR_USERNAME>/jx-docs.git
 cd jx-docs
 ```
@@ -76,27 +76,27 @@ cd jx-docs
 {{% alert %}}
 In case you already have a git clone locally (from before the theme change) then run the following to pull the Docsy theme and dependencies
 
-```bash
-$ git submodule update --init --recursive
+```sh
+git submodule update --init --recursive
 ```
 {{% /alert %}}
 
 Add the conventional upstream `git` remote in order to fetch changes from the `jx-docs` master
 branch and to create pull requests:
 
-```bash
-$ git remote add upstream https://github.com/jenkins-x/jx-docs.git
+```sh
+git remote add upstream https://github.com/jenkins-x/jx-docs.git
 ```
 
 Let's check if everything went right by listing all known remotes:
 
-```shell
-$ git remote -v
+```sh
+git remote -v
 ```
 
 The output should look similar to:
 
-```
+```sh
 origin    git@github.com:<YOUR_USERNAME>/jx-docs.git (fetch)
 origin    git@github.com:<YOUR_USERNAME>/jx-docs.git (push)
 upstream  https://github.com/jenkins-x/jx-docs.git (fetch)
@@ -121,21 +121,21 @@ To make it as simple as possible, we've created and published Docker images inst
 
 In order to use this setup, first make sure you're in the folder with your local cloned copy of the `jx-docs` repo, then run the following command to download and start the Hugo server:
 
-```bash
-$ docker-compose up -d server
+```sh
+docker-compose up -d server
 ```
 
 This will make the site available on http://localhost:1313/ and it will auto-update when you save changes to any of the files in the repo.
 
 To be able to see what's going on, and know when the site is ready (can take a bit to process when you first start up), you can run this command (ctrl-c to stop watching the logs):
 
-```bash
-$ docker-compose logs -f server
+```sh
+docker-compose logs -f server
 ```
 
 You'll know the site is ready when you see something like:
 
-```
+```sh
 server_1        | Watching for changes in /src/{assets,content,layouts,static,themes}
 server_1        | Watching for config changes in /src/config.toml, /src/themes/docsy/config.toml
 server_1        | Environment: "development"
@@ -149,28 +149,28 @@ As you're changing things and adding new content, your local Hugo server might g
 
 #### See the Hugo Logs
 
-```cmd
-$ docker-compose logs -f server
+```sh
+docker-compose logs -f server
 ```
 
 Leave `-f` off if you don't want new log entries to show up in your console. (ctrl-c to escape when `-f` is on)
 
 #### Restart the Hugo Server
 
-```cmd
-$ docker-compose restart server
+```sh
+docker-compose restart server
 ```
 
 #### Stop the Hugo Server
 
-```cmd
-$ docker-compose stop server
+```sh
+docker-compose stop server
 ```
 
 or
 
-```cmd
-$ docker-compose down
+```sh
+docker-compose down
 ```
 
 ### Install Hugo
@@ -181,8 +181,8 @@ You need a recent extended version (we recommend version 0.58 or later) of Hugo 
 
 Check you're using `Hugo extended` and a version higher than `0.58.0` :
 
-```bash
-$ hugo version
+```sh
+hugo version
 ```
 
 The output should look something like `Hugo Static Site Generator v0.58.3/extended darwin/amd64 BuildDate: unknown`
@@ -191,14 +191,14 @@ The output should look something like `Hugo Static Site Generator v0.58.3/extend
 
 To build or update your site’s CSS resources, you also need [PostCSS](https://postcss.org/) to create the final assets. If you need to install it, you must have a recent version of `NodeJS` installed on your machine so you can use `npm`, the Node package manager. By default `npm` installs tools under the directory where you run `npm install`:
 
-```bash
-$ sudo npm install -D --save autoprefixer
-$ sudo npm install -D --save postcss-cli
+```sh
+sudo npm install -D --save autoprefixer
+sudo npm install -D --save postcss-cli
 ```
 
 Get local copies of the project submodules so you can build and run your site locally:
 
-```bash
+```sh
 git submodule update --init --recursive
 ```
 
@@ -206,13 +206,13 @@ git submodule update --init --recursive
 
 Build the site:
 
-```bash
-$ hugo server
+```sh
+hugo server
 ```
 
 It's ready when you see something like this:
 
-```bash
+```sh
 Environment: "development"
 Serving pages from memory
 Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
@@ -228,9 +228,9 @@ It may be a good idea to run the server in a separate terminal so that you can k
 
 In a later section we'll go over how to use other tools to check for spelling errors or typos, as well as checking that all links are working as expected. If you don't want to use the supplied docker approach, these tools will need to be installed locally as well:
 
-```bash
-$ npm i markdown-spellcheck -g
-$ curl https://htmltest.wjdp.uk | sudo bash -s -- -b /usr/local/bin
+```sh
+npm i markdown-spellcheck -g
+curl https://htmltest.wjdp.uk | sudo bash -s -- -b /usr/local/bin
 ```
 
 See [markdown-spellcheck install](https://github.com/lukeapage/node-markdown-spellcheck#cli-usage) and [htmltest install](https://github.com/wjdp/htmltest#system-wide-install) pages for more details on other ways to install them.
@@ -260,22 +260,22 @@ We'll go though each of the steps below in more detail
 
 First, ensure that your local repository is up-to-date with the latest version of `jx-docs`. More details on [GitHub help](https://help.github.com/articles/syncing-a-fork/)
 
-```shell
-$ git fetch upstream
-$ git checkout master
-$ git merge upstream/master
+```sh
+git fetch upstream
+git checkout master
+git merge upstream/master
 ```
 
 You've now updated your local copy of the repository. To update your fork on GitHub, push your changes:
 
-```shell
-$ git push origin master
+```sh
+git push origin master
 ```
 
 Create a new branch for the changes you'd like to make:
 
-```shell
-$ git checkout -b <BRANCH-NAME>
+```sh
+git checkout -b <BRANCH-NAME>
 ```
 
 You can check on which branch your are with `git branch`. You should see a list of all local branches. The current branch is indicated with a little asterisk.
@@ -298,8 +298,8 @@ The Jenkins X docs make heavy use of Jenkins X's [archetypes][] feature. All con
 
 Adding new content to the Jenkins X docs follows the same pattern, regardless of the content section:
 
-```
-$ docker-compose run server new <DOCS-SECTION>/<new-content-lowercase>.md
+```sh
+docker-compose run server new <DOCS-SECTION>/<new-content-lowercase>.md
 ```
 
 ### Commit and push your changes
@@ -310,16 +310,16 @@ When you've finished, and verified that everything looks good (using the Hugo se
 
 We're using a tool called [htmltest](https://github.com/wjdp/htmltest) to check that links are still valid etc. so you just need to run the following commands to build the site locally, and verify that everything looks good:
 
-```bash
-$ docker-compose run server hugo
-$ docker-compose up linkchecker
+```sh
+docker-compose run server hugo
+docker-compose up linkchecker
 ```
 
 If using a locally installed Hugo/htmltest, use these commands instead:
 
-```bash
-$ hugo
-$ htmltest -c .htmltest.yml
+```sh
+hugo
+htmltest -c .htmltest.yml
 ```
 
 #### Checking Spelling
@@ -328,14 +328,14 @@ For spell checking, we're using [node-markdown-spellcheck](https://github.com/lu
 
 To make this as simple as possible, just run the following command
 
-```bash
-$ docker-compose up spellchecker
+```sh
+docker-compose up spellchecker
 ```
 
 If using a locally installed Hugo/markdown-spellcheck, use these commands instead:
 
-```bash
-$  mdspell --en-us --ignore-numbers --ignore-acronyms --report "content/**/*.md"
+```sh
+mdspell --en-us --ignore-numbers --ignore-acronyms --report "content/**/*.md"
 ```
 
 This will output any issue the spell checker have found.
@@ -347,8 +347,8 @@ Also, please try and keep the list alphabetically sorted; makes it easier to nav
 
 If everything is good, you can commit your changes, and push them to your fork:
 
-```bash
-$ git push --set-upstream origin <BRANCH-NAME>
+```sh
+git push --set-upstream origin <BRANCH-NAME>
 ```
 
 If you need to push more commits to the same branch, you can just use `git push` going forward; set-upstream is only needed once.
@@ -383,10 +383,10 @@ Once the review is done, your changes will be merged into the master branch, and
 {{% alert %}}
 In case you need to update your PR/branch because js-docs/master have been updated since you submitted your PR, run the followin `git` command to pull all the changes to your local environment and then push them to your PR/branch:
 
-```bash
-$ git fetch upstream
-$ git merge upstream/master
-$ git push
+```sh
+git fetch upstream
+git merge upstream/master
+git push
 ```
 
 If you experience Merge Conflicts, there's a good [article on GitHub](https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line) that helps explain what to do
@@ -452,7 +452,7 @@ type CommandInterface interface {
 
 Blockquotes can be added to the Jenkins X documentation using [typical Markdown blockquote syntax][bqsyntax]:
 
-```
+```text
 > Without the threat of punishment, there is no joy in flight.
 ```
 
@@ -462,7 +462,7 @@ The preceding blockquote will render as follows in the Jenkins X docs:
 
 However, you can add a quick and easy `<cite>` element (added on the client via JavaScript) by separating your main blockquote and the citation with a hyphen with a single space on each side:
 
-```
+```text
 > Without the threat of punishment, there is no joy in flight. - [Kobo Abe](https://en.wikipedia.org/wiki/Kobo_Abe)
 ```
 

--- a/content/en/docs/contributing/documentation/apidocs.md
+++ b/content/en/docs/contributing/documentation/apidocs.md
@@ -24,8 +24,8 @@ The custom resource documentation is generated using the [same toolchain](https:
 The HTML docs are generated via an [OpenAPI specification](https://github.com/jenkins-x/jx/tree/master/docs/apidocs/openapi-spec) which in turn is generated from [Go Structs](https://github.com/jenkins-x/jx/tree/master/pkg/client/openapi) which are generated from the code comments.
 To generate the structs and the OpenAPI specification run:
 
- ```bash
- $ make generate-openapi
+ ```sh
+ make generate-openapi
  ```
 
  {{% alert %}}
@@ -35,7 +35,7 @@ To generate the structs and the OpenAPI specification run:
 
  and to generate the HTML run:
 
- ```bash
+ ```sh
  make generate-docs
  ```
 

--- a/content/en/docs/getting-started/first-project/create-quickstart.md
+++ b/content/en/docs/getting-started/first-project/create-quickstart.md
@@ -5,27 +5,27 @@ description: How to create a new quickstart application and import it into Jenki
 weight: 10
 ---
 
-Quickstarts are pre-made applications you can start a project from, instead of starting from scratch. 
-                
+Quickstarts are pre-made applications you can start a project from, instead of starting from scratch.
+
 You can create new applications from our list of curated Quickstart applications via the [jx create quickstart](/commands/jx_create_quickstart) command.
 
 
-```shell
-$ jx create quickstart
+```sh
+jx create quickstart
 ```
 
 You are then prompted for a list of quickstarts to choose from.
 
 If you know the language you wish to use you can filter the list of quickstarts shown via:
 
-```shell
-$ jx create quickstart -l go
+```sh
+jx create quickstart -l go
 ```
 
 Or use a text filter to filter on the project names:
 
-```shell
-$ jx create quickstart -f http
+```sh
+jx create quickstart -f http
 ```
 
 ### What happens when you create a quickstart
@@ -33,7 +33,7 @@ $ jx create quickstart -f http
 Once you have chosen the project to create and given it a name the following is automated for you:
 
 * creates a new application from the quickstart in a sub directory
-* add your source code into a git repository 
+* add your source code into a git repository
 * create a remote git repository on a git service, such as [GitHub](https://github.com)
 * push your code to the remote git service
 * adds default files:
@@ -42,7 +42,7 @@ Once you have chosen the project to create and given it a name the following is 
   * Helm chart to run your application inside Kubernetes
 * register a webhook on the remote git repository to your teams Jenkins
 * add the git repository to your teams Jenkins
-* trigger the first pipeline 
+* trigger the first pipeline
 
 ### How do quickstarts work?
 
@@ -55,12 +55,12 @@ When you use [jx create](/docs/getting-started/setup/create-cluster/), [jx insta
 Depending on your JenkinsX installation type (Serverless Jenkins vs. Static Master Jenkin), you can view all the languages supported via build packs on your machine via:
 
 *Serverless Jenkins*:
-```shell
+```sh
 ls -al ~/.jx/draft/packs/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/packs
 ```
 
 *Static Master Jenkins*:
-```shell
+```sh
 ls -al ~/.jx/draft/packs/github.com/jenkins-x-buildpacks/jenkins-x-classic/packs
 ```
 
@@ -71,7 +71,7 @@ Then when you create a quickstart, use [jx create spring](/docs/using-jx/common-
   * `Dockerfile` to package the application as a docker image
   * `Jenkinsfile` to implement the CI / CD pipelines using declarative pipeline as code
   * Helm Charts to deploy the application on Kubernetes and to implement [Preview Environments](/docs/concepts/features/#preview-environments)
-   
+
 ## Adding your own Quickstarts
 
 If you would like to submit a new Quickstart to Jenkins X please just [raise an issue](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20quickstart&body=Please%20add%20this%20github%20quickstart:) with the URL in GitHub of your quickstart and we can fork it it into the [quickstart organisation](https://github.com/jenkins-x-quickstarts) so it appears in the `jx create quickstart` menu.
@@ -80,8 +80,8 @@ Or if you are part of an open source project and wish to curate your own set of 
 
 Until we do that you can still use your own Quickstarts in the `jx create quickstart` command via the `-g` or `--organisations` command line argument. e.g.
 
-```shell
-$ jx create quickstart  -l go --organisations my-github-org
+```sh
+jx create quickstart  -l go --organisations my-github-org
 ```
 
 Then all quickstarts found in `my-github-org` will be listed in addition to the Jenkins X quickstarts.
@@ -93,29 +93,29 @@ You can configure at a team level the quickstarts which are presented to you in 
 To add the location of a set of quickstarts you can use the [jx create quickstartlocation](/commands/jx_create_quickstartlocation/) command.
 
 
-```shell
-$ jx create quickstartlocation --url https://mygit.server.com --owner my-quickstarts
-```  
+```sh
+jx create quickstartlocation --url https://mygit.server.com --owner my-quickstarts
+```
 
 If you omit the `--url` argument the command will assume its a [GitHub](https://github.com/) repository. Note that both public and private repositories are supported.
 
-This means you can have your own shared private quickstarts to reuse within your organisation. Of course we'd obviously prefer you to [share your quickstarts with us via open source](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20quickstart&body=Please%20add%20this%20github%20quickstart:) then we can include your quickstart with the entire [community](/community) - but there may be times you want to curate your own internal quickstarts using proprietary software. 
+This means you can have your own shared private quickstarts to reuse within your organisation. Of course we'd obviously prefer you to [share your quickstarts with us via open source](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20quickstart&body=Please%20add%20this%20github%20quickstart:) then we can include your quickstart with the entire [community](/community) - but there may be times you want to curate your own internal quickstarts using proprietary software.
 
-You can also specify `--includes` or `--excludes` patterns to filter the names of the repositories where `*` matches anything and `foo*` matches anything starting with `foo`. e.g. you could just include the languages and technologies your organisation supports and exclude the rest etc. 
+You can also specify `--includes` or `--excludes` patterns to filter the names of the repositories where `*` matches anything and `foo*` matches anything starting with `foo`. e.g. you could just include the languages and technologies your organisation supports and exclude the rest etc.
 
 Also note that you can use the alias of `qsloc` instead of `quickstartlocation` if you like shorter aliases ;)
 
 You can then view the current quickstart locations for your team via the [jx get quickstartlocations](/commands/jx_get_quickstartlocations/) command:
 
-```shell
-$ jx get quickstartlocations
-```  
+```sh
+jx get quickstartlocations
+```
 
 Or using an abbreviation
-  
-```shell
-$ jx get qsloc
-```  
-  
-There is also [jx delete quickstartlocation](/commands/jx_delete_quickstartlocation/) if you need to remove a git organisation.  
-                                                                                                 
+
+```sh
+jx get qsloc
+```
+
+There is also [jx delete quickstartlocation](/commands/jx_delete_quickstartlocation/) if you need to remove a git organisation.
+

--- a/content/en/docs/getting-started/promotion/_index.md
+++ b/content/en/docs/getting-started/promotion/_index.md
@@ -11,7 +11,7 @@ The CD Pipelines of Jenkins X automate the [promotion](/docs/concepts/features/#
 
 To manually Promote a version of your application to an environment use the [jx promote](/commands/jx_promote) command.
 
-```shell 
+```sh
 jx promote --app myapp --version 1.2.3 --env production
 ```
 
@@ -20,7 +20,7 @@ The command waits for the promotion to complete, logging details of its progress
 e.g. to wait for 5 hours
 
 
-```shell 
+```sh
 jx promote  --app myapp --version 1.2.3 --env production --timeout 5h
 ```
 
@@ -46,35 +46,35 @@ If you wish to search your helm repositories for an application to promote you c
 
 e.g. to find a `redis` chart to promote to staging you could do:
 
-```shell 
+```sh
 jx promote -f redis --env staging
 ```
 
-For databases you may want to alias (via `--alias`) the name of the chart to be a logical name for the kind of database you need. As you may need multiple databases in the same environment for different microservices. e.g. 
+For databases you may want to alias (via `--alias`) the name of the chart to be a logical name for the kind of database you need. As you may need multiple databases in the same environment for different microservices. e.g.
 
-```shell 
+```sh
 jx promote -f postgres --alias salesdb --env staging
 ```
 
 If you cannot find the particular application you are looking for you may need to add a helm chart repository to your helm installation via:
 
-```shell 
+```sh
 helm repo add myrepo https://something.acme.com/charts/
 ```
 
 for example to add the stable community charts:
 
-```shell 
-$ helm repo add incubator https://kubernetes-charts.storage.googleapis.com/
+```sh
+helm repo add incubator https://kubernetes-charts.storage.googleapis.com/
 "stable" has been added to your repositories
 ```
-  
+
 to add the incubator community charts:
 
-```shell 
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+```sh
+helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 "incubator" has been added to your repositories
-```  
+```
 
 There are huge numbers of [charts already created and maintained by the community](https://github.com/helm/charts/tree/master/stable) these days. If you want to add your own apps developed outside of Jenkins X you just need to package the YAML as a helm chart and install it in a chart repository.
 

--- a/content/en/docs/getting-started/setup/boot/_index.md
+++ b/content/en/docs/getting-started/setup/boot/_index.md
@@ -8,7 +8,7 @@ lastmod: 2017-02-01
 categories: [getting started]
 keywords: [install]
 weight: 10
-aliases: 
+aliases:
   - /getting-started/boot
   - /docs/reference/boot
 ---
@@ -23,19 +23,19 @@ _Jenkins X Boot_ uses the following approach:
   * use Terraform to create your kubernetes clusters + the associated cloud resources
   * use your cloud providers web console to create a new kubernetes cluster
   * use `jx create cluster --skip-installation` e.g.
-``` 
+``` sh
 jx create cluster gke --skip-installation
 ```
-  
+
   * use some custom tool of your choice or maybe its provided to you by your operations team
 
 * you may want to verify you can communicate correctly with your kubernetes cluster via:
-``` 
+``` sh
 kubectl get ns
 ```
 
 * run the [jx boot](/commands/jx_boot) command:
-``` 
+```sh
 jx boot
 ```
 
@@ -50,7 +50,7 @@ The [jx boot](/commands/jx_boot) interprets the boot pipeline using your local `
 
 
 #### Pre and Post Validation
- 
+
 Before any installation is attempted it runs the [jx step verify preinstall](/commands/jx_step_verify_preinstall/) command to check everything looks OK. If you are using Terraform (so that your 'jx-requirements.yml' file has `terraform: true`) it will fail if Terraform has not created the required cloud resources. Otherwise they are lazily created for you if they don't exist.
 
 Once the installation has completed the [jx step verify install](/commands/jx_step_verify_install/) command is run to verify your installation is valid.
@@ -59,7 +59,7 @@ Once the installation has completed the [jx step verify install](/commands/jx_st
 
 At any time you can re-run [jx boot](/commands/jx_boot) to re-apply any changes in your configuration.
 
-So just edit anything in the configuration you like and re-run [jx boot](/commands/jx_boot) - whether thats to add or remove Apps, to change parameters or configuration or upgrade or downgrade versions of dependencies. 
+So just edit anything in the configuration you like and re-run [jx boot](/commands/jx_boot) - whether thats to add or remove Apps, to change parameters or configuration or upgrade or downgrade versions of dependencies.
 
 ## Requirements
 
@@ -80,7 +80,7 @@ Boot currently supports the following options for managing secrets:
 
 This is the default or can be explicitly configured via `secretStorage: local`:
 
-```yaml 
+```yaml
 cluster:
   provider: gke
 environments:
@@ -98,7 +98,7 @@ If enabled secrets are loaded/saved into the folder `~/.jx/localSecrets/$cluster
 
 This is the recommended approach when using GKE or EKS providers. It can be explicitly configured via `secretStorage: vault`:
 
-```yaml 
+```yaml
 cluster:
   provider: gke
 environments:
@@ -122,11 +122,11 @@ Jenkins X supports a number of engines for handling webhooks and optionally supp
 
 ### Prow
 
-[Prow](/docs/reference/components/prow/) is currently the default webhook and [ChatOps](/docs/using-jx/faq/chatops) engine when using [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) and GitHub. 
- 
+[Prow](/docs/reference/components/prow/) is currently the default webhook and [ChatOps](/docs/using-jx/faq/chatops) engine when using [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) and GitHub.
+
 Its configured via the `webhook: prow` in `jx-requirements.yml`
 
-```yaml 
+```yaml
 cluster:
   provider: gke
 environments:
@@ -142,17 +142,17 @@ storage:
   repository:
     enabled: false
 webhook: prow
-``` 
+```
 
 ### Lighthouse
 
-[Lighthouse](/architecture/lighthouse/) is currently the default webhook and [ChatOps](/docs/using-jx/faq/chatops) engine when using [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) and a git server other than https://github.com. 
+[Lighthouse](/architecture/lighthouse/) is currently the default webhook and [ChatOps](/docs/using-jx/faq/chatops) engine when using [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) and a git server other than https://github.com.
 
-Once Lighthouse is more stable and well tested we'll make it the default for all installations using [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/). 
- 
+Once Lighthouse is more stable and well tested we'll make it the default for all installations using [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/).
+
 Its configured via the `webhook: lighthouse` in `jx-requirements.yml`
 
-```yaml 
+```yaml
 cluster:
   provider: gke
 environments:
@@ -168,7 +168,7 @@ storage:
   repository:
     enabled: false
 webhook: lighthouse
-``` 
+```
 
 ### Jenkins
 
@@ -189,8 +189,8 @@ For evaluation purposes you could use a private GitHub account as the owner of t
 
 This is the default if you don't specify anything.
 
- 
-```yaml 
+
+```yaml
 cluster:
   environmentGitOwner: myorg
   provider: gke
@@ -207,13 +207,13 @@ storage:
   repository:
     enabled: false
 webhook: prow
-``` 
+```
 
 ### GitHub Enterprise
 
 The configuration is similar to the above but you need to specify the URL of the `gitServer` (if it differs from https://github.com) and `gitKind: github`
 
-```yaml   
+```yaml
 cluster:
   provider: gke
   environmentGitOwner: myorg
@@ -237,13 +237,13 @@ storage:
     enabled: true
     url: "gs://jx-logs"
 webhook: lighthouse
-``` 
+```
 
 ### Bitbucket Server
 
 For this specify the URL of the `gitServer` and `gitKind: bitbucketserver`. If you want to use [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) then make sure you specify the [lighthouse webhook](#webhook) via `webhook: lighthouse`.
 
-```yaml   
+```yaml
 cluster:
   provider: gke
   environmentGitOwner: myorg
@@ -267,13 +267,13 @@ storage:
     enabled: true
     url: "gs://jx-logs"
 webhook: lighthouse
-``` 
+```
 
 ### Bitbucket Cloud
 
 For this specify`gitKind: bitbucketcloud`. If you want to use [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) then make sure you specify the [lighthouse webhook](#webhook) via `webhook: lighthouse`.
 
-```yaml   
+```yaml
 cluster:
   provider: gke
   environmentGitOwner: myorg
@@ -296,14 +296,14 @@ storage:
     enabled: true
     url: "gs://jx-logs"
 webhook: lighthouse
-``` 
+```
 
 
 ### Gitlab
 
 For this specify the URL of the `gitServer` and `gitKind: gitlab`. If you want to use [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with [Tekton](https://tekton.dev/) then make sure you specify the [lighthouse webhook](#webhook) via `webhook: lighthouse`.
 
-```yaml   
+```yaml
 cluster:
   provider: gke
   environmentGitOwner: myorg
@@ -327,7 +327,7 @@ storage:
     enabled: true
     url: "gs://jx-logs"
 webhook: lighthouse
-``` 
+```
 
 ## Storage
 
@@ -335,7 +335,7 @@ the [jx-requirements.yml](https://github.com/jenkins-x/jenkins-x-boot-config/blo
 
 e.g. the following `jx-requirements.yml` file enables long term storage:
 
-```yaml 
+```yaml
 cluster:
   provider: gke
 environments:
@@ -352,7 +352,7 @@ storage:
     enabled: false
 ```
 
-You can also specify the URLs of the storage buckets in the `storage` section. The following URL syntax is supported 
+You can also specify the URLs of the storage buckets in the `storage` section. The following URL syntax is supported
 
 * `gs://anotherBucket/mydir/something.txt` : using a GCS bucket on GCP
 * `s3://nameOfBucket/mydir/something.txt` : using S3 bucket on AWS
@@ -362,7 +362,7 @@ You can also specify the URLs of the storage buckets in the `storage` section. T
 
 e.g.
 
-```yaml 
+```yaml
 cluster:
   provider: gke
 environments:
@@ -386,11 +386,11 @@ For more details see the [Storage Guide](/architecture/storage).
 
 ## Ingress
 
-If you don't specify anything in your [jx-requirements.yml](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/jx-requirements.yml) file then boot will default to using HTTP (rathter than HTTPS) and using [nip.io](https://nip.io/) as the DNS mechanism. 
+If you don't specify anything in your [jx-requirements.yml](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/jx-requirements.yml) file then boot will default to using HTTP (rathter than HTTPS) and using [nip.io](https://nip.io/) as the DNS mechanism.
 
 After running boot your `jx-requirements.yml` may look like:
 
-```yaml 
+```yaml
 cluster:
   provider: gke
   clusterName: my-cluster-name
@@ -424,7 +424,7 @@ If you wish to enable external DNS (to automatically register DNS names for all 
 
 You can also update your configuration to enable TLS via `ingress.lts.enabled = true`. Here's an example:
 
-```yaml 
+```yaml
 cluster:
   clusterName: mycluster
   environmentGitOwner: myorg
@@ -462,7 +462,7 @@ storage:
 webhook: prow
 ```
 
-## Upgrading 
+## Upgrading
 
 With `jx boot` all of the versions and configuration is in git so its easy to manage change via GitOps either automatically or manually.
 
@@ -470,17 +470,17 @@ With `jx boot` all of the versions and configuration is in git so its easy to ma
 
 You can enable auto upgrades in the `jx-requirements.yml` via the following (where `schedule` is a cron expression)
 
-```yaml 
+```yaml
 autoUpdate:
   enabled: true
-  schedule: "0 0 23 1/1 * ? *"  
-``` 
+  schedule: "0 0 23 1/1 * ? *"
+```
 
 When auto upgrades are enabled a `CronJob` is run which periodically checks for changes in the [version stream](/docs/concepts/version-stream/) or [boot configuration](https://github.com/jenkins-x/jenkins-x-boot-config). If changes are detected the [jx step boot upgrade](/commands/jx_step_boot_upgrade/) will create a Pull Request on your development git repository. Once that merges the boot configuration is upgraded and boot will be re-run inside a tekton pipeline to upgrade your installation.
 
 ### Manual upgrades
 
-You can manually run the [jx step boot upgrade](/commands/jx_step_boot_upgrade/) command at any time which if there have been changes in [version stream](/docs/concepts/version-stream/) or [boot configuration](https://github.com/jenkins-x/jenkins-x-boot-config) will create a Pull Request on your development git repository. 
+You can manually run the [jx step boot upgrade](/commands/jx_step_boot_upgrade/) command at any time which if there have been changes in [version stream](/docs/concepts/version-stream/) or [boot configuration](https://github.com/jenkins-x/jenkins-x-boot-config) will create a Pull Request on your development git repository.
 
 Once that merges the boot configuration is upgraded and boot will be re-run inside a tekton pipeline to upgrade your installation.
 
@@ -495,7 +495,7 @@ Jenkins X is integrated with [velero](https://velero.io) to support backing up t
 
 To enable velero add the following to your `jx-requirements.yml`:
 
-```yaml 
+```yaml
 storage:
   backup:
     enabled: true
@@ -504,4 +504,4 @@ velero:
   namespace: velero
 ```
 
-Using whatever your cloud providers bucket URLs are. For more background checkout the [storage guide](/docs/managing-jx/common-tasks/storage/) 
+Using whatever your cloud providers bucket URLs are. For more background checkout the [storage guide](/docs/managing-jx/common-tasks/storage/)

--- a/content/en/docs/getting-started/setup/boot/how-it-works.md
+++ b/content/en/docs/getting-started/setup/boot/how-it-works.md
@@ -45,11 +45,11 @@ If you look at the current [env/parameters.yaml](https://github.com/jstrachan/en
 This means we can populate all the Parameters we need on startup then refer to them from `values.tmpl.yaml` to populate the tree of values to then inject those into Vault.
 
 
-### Populating the `parameters.yaml` file 
+### Populating the `parameters.yaml` file
 
 We can then use the new step to populate the `parameters.yaml` file in the Pipeline via this command in the `env` folder:
 
-``` 
+```sh
 jx step create values --name parameters
 ```
 
@@ -61,16 +61,16 @@ This uses the [parameters.schema.json](https://github.com/jenkins-x/jenkins-x-bo
 
 Rather than a huge huge deeply nested values.yaml file we can have a tree of files for each App only include the App specific configuration in each folder. e.g.
 
-``` 
+```sh
 env/
   values.yaml   # top level configuration
   prow/
     values.yaml # prow specific config
   tekton/
-    values.yaml  # tekton specific config 
+    values.yaml  # tekton specific config
 ```
-  
-  
+
+
 #### values.tmpl.yaml templates
 
 When using `jx step helm apply` we now allow `values.tmpl.yaml` files to use go/helm templates just like `templates/foo.yaml` files support inside helm charts so that we can generate value/secret strings which can use templating to compose things from smaller secret values. e.g. creating a maven `settings.xml` file or docker `config.json` which includes many user/passwords for different registries.

--- a/content/en/docs/getting-started/setup/create-cluster/amazon/_index.md
+++ b/content/en/docs/getting-started/setup/create-cluster/amazon/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Amazon 
+title: Amazon
 linktitle: Amazon
 description: How to create a kubernetes cluster on Amazon (AWS)
 date: 2017-02-01
@@ -31,12 +31,12 @@ Then follow the instructions to [create a cluster on AWS with kops](https://kube
 Ensure you [have installed the jx CLI](/docs/getting-started/setup/install/) then for kops use:
 
 
-```
+```sh
 jx create cluster aws --skip-installation
 ```
 
 or for EKS use:
 
-```
+```sh
 jx create cluster eks --skip-installation
 ```

--- a/content/en/docs/getting-started/setup/create-cluster/azure.md
+++ b/content/en/docs/getting-started/setup/create-cluster/azure.md
@@ -1,5 +1,5 @@
 ---
-title: Azure 
+title: Azure
 linktitle: Azure
 description: How to create a kubernetes cluster on Azure
 date: 2017-02-01
@@ -13,6 +13,6 @@ You may find [this blog helpful](https://cloudblogs.microsoft.com/opensource/201
 
 Otherwise ensure you [have installed the jx CLI](/docs/getting-started/setup/install/) then run:
 
-```
+```sh
 jx create cluster aks --skip-installation
 ```

--- a/content/en/docs/getting-started/setup/create-cluster/google.md
+++ b/content/en/docs/getting-started/setup/create-cluster/google.md
@@ -1,5 +1,5 @@
 ---
-title: Google 
+title: Google
 linktitle: Google
 description: How to create a kubernetes cluster on the Google Cloud Platform (GCP)
 date: 2017-02-01
@@ -22,7 +22,7 @@ Now you can click the `create cluster` button on the [kubernetets clusters](http
 
 
 
-## Using gcloud                                                                            
+## Using gcloud
 
 The CLI tool for working with google cloud is called `gcloud`. If you have not done so already please [install gcloud](https://cloud.google.com/sdk/install)
 
@@ -41,7 +41,7 @@ You can then create a cluster with `gcloud` by [following these instructions](ht
 
 ## Connecting to your cluster
 
-Once you have created a cluster, you need to connect to it so you can access it via the `kubectl` or [jx](/docs/getting-started/setup/install/) command line tools. 
+Once you have created a cluster, you need to connect to it so you can access it via the `kubectl` or [jx](/docs/getting-started/setup/install/) command line tools.
 
 To do this click on the `Connect` button on the [Kubernetes Engine page](https://console.cloud.google.com/kubernetes/list) in the [Google Console](https://console.cloud.google.com/)
 
@@ -49,6 +49,6 @@ To do this click on the `Connect` button on the [Kubernetes Engine page](https:/
 
 You should now be able to use the `kubectl` and `jx` CLI tools on your laptop to talk to the GKE cluster. e.g. this command should list the nodes in your cluster:
 
-``` 
+```sh
 kubectl get node
 ```

--- a/content/en/docs/getting-started/setup/install/_index.md
+++ b/content/en/docs/getting-started/setup/install/_index.md
@@ -14,7 +14,7 @@ Pick the most suitable instructions for your operating system:
 
 On a Mac you can use [brew](https://brew.sh/):
 
-```shell
+```sh
 brew tap jenkins-x/jx
 brew install jx
 ```
@@ -24,21 +24,29 @@ To install Jenkins X on macOS without brew, download the `.tar` file, and unarch
 1.  Download the `jx` binary archive using `curl` and pipe (`|`) the compressed archive to
     the `tar` command:
 
-        curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-darwin-amd64.tar.gz" | tar xzv "jx"
+```sh
+curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-darwin-amd64.tar.gz" | tar xzv "jx"
+```
 
     or, if you don't have `jq` installed:
 
-        curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent "https://github.com/jenkins-x/jx/releases/latest" | sed 's#.*tag/\(.*\)\".*#\1#')/jx-darwin-amd64.tar.gz" | tar xzv "jx"
+```sh
+curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent "https://github.com/jenkins-x/jx/releases/latest" | sed 's#.*tag/\(.*\)\".*#\1#')/jx-darwin-amd64.tar.gz" | tar xzv "jx"
+```
 
 
 2.  Install the `jx` binary by moving it to a location which should be on your environments PATH, using
     the `mv` command:
 
-        sudo mv jx /usr/local/bin
+```sh
+sudo mv jx /usr/local/bin
+```
 
 3. Run `jx version` to make sure you're on the latest stable version
 
-        jx version
+```sh
+jx version
+```
 
 ## Linux
 
@@ -47,21 +55,28 @@ To install Jenkins X on Linux, download the `.tar` file, and unarchive it in a d
 1.  Download the `jx` binary archive using `curl` and pipe (`|`) the compressed archive to
     the `tar` command:
 
-        curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-linux-amd64.tar.gz" | tar xzv "jx"
+```sh
+curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-linux-amd64.tar.gz" | tar xzv "jx"
+```
 
     or, if you don't have `jq` installed:
 
-        curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent "https://github.com/jenkins-x/jx/releases/latest" | sed 's#.*tag/\(.*\)\".*#\1#')/jx-linux-amd64.tar.gz" | tar xzv "jx"
-
+```sh
+curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent "https://github.com/jenkins-x/jx/releases/latest" | sed 's#.*tag/\(.*\)\".*#\1#')/jx-linux-amd64.tar.gz" | tar xzv "jx"
+```
 
 2.  Install the `jx` binary by moving it to a location which should be on your environments PATH, using
     the `mv` command:
 
-        sudo mv jx /usr/local/bin
+```sh
+sudo mv jx /usr/local/bin
+```
 
 3. Run `jx version` to make sure you're on the latest stable version
 
-        jx version
+```sh
+jx version
+```
 
 ## Windows
 
@@ -84,7 +99,7 @@ Shell:
 
 You can update to the latest version of Jenkins X using Chocolatey:
 
-```cmd
+```sh
 choco upgrade jenkins-x
 ```
 
@@ -92,13 +107,13 @@ choco upgrade jenkins-x
 
   To install the `jx` binary run:
 
-  ```cmd
+  ```sh
   scoop install jx
   ```
 
   To upgrade the `jx` binary run:
 
-  ```cmd
+  ```sh
   scoop update jx
   ```
 
@@ -111,25 +126,31 @@ commands:
 1.  Open the [GCP Cloud Shell](https://cloud.google.com/shell/docs/starting-cloud-shell),
     and choose your GCP project for Jenkins X.
 
-    {{% alert %}}
-    It is highly recommended that you use Google Chrome browser with
-    GCP Cloud Shell, as you may experience issues using other
-    browsers.
-    {{% /alert %}}
+{{% alert %}}
+It is highly recommended that you use Google Chrome browser with
+GCP Cloud Shell, as you may experience issues using other
+browsers.
+{{% /alert %}}
 
 2.  In GCP Cloud Shell, download the `jx` binary archive using `curl` and pipe (`|`) the compressed archive to
     the `tar` command:
 
-        curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-linux-amd64.tar.gz" | tar xzv "jx"
+```sh
+curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-linux-amd64.tar.gz" | tar xzv "jx"
+```
 
 3.  Move the `jx` exectutable into the executable directory with this
     command:
 
-        sudo mv jx /usr/local/bin
+```sh
+sudo mv jx /usr/local/bin
+```
 
 4. Run `jx version` to make sure you're on the latest stable version
 
-        jx version
+```sh
+jx version
+```
 
 Once you have the `jx` binary installed you can then [configure a Jenkins X cluster on Google Kubernetes Engine](/getting-started/create-cluster/).
 
@@ -143,10 +164,14 @@ Or you can try [build it yourself](https://github.com/jenkins-x/jx/blob/master/d
 
 To find out the available commands type:
 
-    jx
+```sh
+jx
+```
 
 Or to get help on a specific command, say, `create` then type:
 
-    jx help create
+```sh
+jx help create
+```
 
 You can also browse the [jx command reference documentation](/commands/jx)

--- a/content/en/docs/managing-jx/common-tasks/access-control.md
+++ b/content/en/docs/managing-jx/common-tasks/access-control.md
@@ -36,7 +36,7 @@ Jenkins X ships with a collection of default `Role` objects you can use in the `
 
 To add users use the [jx create user](/commands/jx_create_user/) command:
 
-```shell
+```sh
 jx create user --email "joe@example.com" --login joe --name "Joe Bloggs"
 ```
 
@@ -44,20 +44,20 @@ jx create user --email "joe@example.com" --login joe --name "Joe Bloggs"
 
 To modify the roles for a user, use [jx edit userroles](/commands/jx_edit_userroles/):
 
-```shell
+```sh
 jx edit userrole --login joe
 ```
- 
+
 If you omit the `--login` (`-l`) flag, you will be prompted to pick the user to edit.
 
 For example, to make a user `joe` have the `committer` Role (and remove any existing roles):
 
-```shell
+```sh
 jx edit userrole --login joe --role committer
 ```
 
 If you have fine-grained roles and want to grant multiple roles to a user, you can specify the roles as a comma-separated list:
-```shell
+```sh
 jx edit userrole --login joe --role committer,viewer
 ```
 

--- a/content/en/docs/managing-jx/common-tasks/create-custom-builder.md
+++ b/content/en/docs/managing-jx/common-tasks/create-custom-builder.md
@@ -19,7 +19,7 @@ These images contain a number of pre-installed tools which get constantly update
 
 First you need to create a docker image for your builder. For instance a starting `Dockerfile` can look like this:
 
-```
+```dockerfile
 FROM jenkinsxio/builder-base:latest
 
 # Install your tools and libraries
@@ -30,18 +30,18 @@ CMD ["gcc"]
 
 Now you can build the image and publish it to your registry:
 
-```shell
-export BUILDER_IMAGE=<YOUR_REGISTRY>/<YOUR_BUILDER_IMAGE>:<VERSION> 
+```sh
+export BUILDER_IMAGE=<YOUR_REGISTRY>/<YOUR_BUILDER_IMAGE>:<VERSION>
 docker build -t ${BUILDER_IMAGE} .
-docker push ${BUILDER_IMAGE} 
+docker push ${BUILDER_IMAGE}
 ```
 
-Do not worry, you do not have to run manually these steps every time when a new image needs to be built. 
+Do not worry, you do not have to run manually these steps every time when a new image needs to be built.
 Jenkins X can manage this for you. You just need to push your `Dockerfile` in a repository similar with [this
 ](https://github.com/jenkins-x/builder-go) one. Adjust the `Jenkinsfile` according with your organization and
 application name, and then import the repository into your Jenkins X platform with:
 
-```
+```sh
 jx import --url <REPOSITORY_URL>
 ```
 
@@ -49,7 +49,7 @@ From now on, every time you push a change, Jenkins X will build and publish auto
 
 ### Install the Builder
 
-You can now install your builder either when you install Jenkins X or upgrade it. 
+You can now install your builder either when you install Jenkins X or upgrade it.
 
 Create a `myvalues.yaml` file in your `~/.jx/` folder with the following content:
 
@@ -80,7 +80,7 @@ jenkins:
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
           Dlang:
-            Image: <YOUR_BUILDER_IMAGE> 
+            Image: <YOUR_BUILDER_IMAGE>
             Privileged: true
             RequestCpu: "400m"
             RequestMemory: "512Mi"
@@ -126,15 +126,15 @@ pipeline {
 
 ## Overwrite existing Builders
 
-Jenkins X comes with a number of [pre-installed builders](https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/values.yaml) 
+Jenkins X comes with a number of [pre-installed builders](https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/values.yaml)
 which you can overwrite if required during installation or upgrade.
 
-You just need to build your custom image either based on [builder-base](https://github.com/jenkins-x/builder-base/blob/master/Dockerfile.common) 
+You just need to build your custom image either based on [builder-base](https://github.com/jenkins-x/builder-base/blob/master/Dockerfile.common)
 image or the [builder image](https://hub.docker.com/u/jenkinsxio/) you want to overwrite. See more details above.
 
 Then you can create a `myvalues.yaml` file in your `~/.jx/` folder with the following content:
 
-```
+```yaml
 jenkins:
   Agent:
     PodTemplates:

--- a/content/en/docs/managing-jx/common-tasks/dns.md
+++ b/content/en/docs/managing-jx/common-tasks/dns.md
@@ -12,20 +12,20 @@ However, for users who want services in the cluster to be available on a persona
 ## external-dns
 **NOTE**: *Currently only supported on GKE*
 
-[ExternalDNS](https://github.com/kubernetes-incubator/external-dns) can be used to help expose Kubernetes Services and Ingresses by synchronizing with DNS providers. 
+[ExternalDNS](https://github.com/kubernetes-incubator/external-dns) can be used to help expose Kubernetes Services and Ingresses by synchronizing with DNS providers.
 
 If you are using [jx boot](/docs/getting-started/setup/boot/) to install and configure your setup then modify your `jx-requirements.yml` file to enable `ingress.externalDNS: true` as described in the [boot ingress documentation](/docs/getting-started/setup/boot/#ingress)
 
 
 Otherwise to setup your cluster using ExternalDNS use:
 
-```
+```sh
 jx install --provider gke --tekton --external-dns
 ```
 
 *This will then prompt you for your domain.*
 
-```bash
+```sh
 🙅 developer ~/go-workspace/jx(master)$ jx install --provider gke --tekton --external-dns
 WARNING: When using tekton, only kaniko is supported as a builder
 Context "gke_<your-project-id>_europe-west1-b_<your-cluster-name>" modified.
@@ -37,7 +37,7 @@ helm installed and configured
 
 A CloudDNS managed zone is then created within your clusters GCP Project, the record-sets which expose your services will be created by ExternalDNS within this managed zone.
 
-```
+```sh
 🙅 developer ~/go-workspace()$ gcloud dns managed-zones list
 NAME                           DNS_NAME                   DESCRIPTION                       VISIBILITY
 your-domain-com-zone           your-domain.com.           managed-zone utilised by jx       public
@@ -47,7 +47,7 @@ your-domain-com-zone           your-domain.com.           managed-zone utilised 
 
 Once the installation is complete, a list of name servers will be outputted to the terminal, please update your registrar using these name servers in order to delegate your domain onto Google CloudDNS.
 
-```bash
+```sh
 
         ********************************************************
 
@@ -70,6 +70,6 @@ If you're using Google Domains as your domain registrar please see [here](https:
 
 All services should be available on the same domain, of which is derived as follows:
 
-```
+```sh
 <service>-<namespace>.<your-domain>
 ```

--- a/content/en/docs/managing-jx/common-tasks/security-features.md
+++ b/content/en/docs/managing-jx/common-tasks/security-features.md
@@ -5,31 +5,31 @@ description: Security addons for Jenkins X
 weight: 170
 ---
 
-Jenkins X has a few useful addons that can aid with ensuring the ongoing security of your deployed applications. There are static and container security, as well as dynamic security addons available. 
+Jenkins X has a few useful addons that can aid with ensuring the ongoing security of your deployed applications. There are static and container security, as well as dynamic security addons available.
 
 ### Static security
 
-The [Anchore Engine](https://github.com/anchore/anchore-engine) is used to provide image security, by examining contents of containers either in pull request/review state, or on running containers. 
+The [Anchore Engine](https://github.com/anchore/anchore-engine) is used to provide image security, by examining contents of containers either in pull request/review state, or on running containers.
 
 This was introduced [in this blog post](https://jenkins.io/blog/2018/05/08/jenkins-x-anchore/)
 
-To enable this run the following command and let it prepare the services: 
+To enable this run the following command and let it prepare the services:
 
-```
+```sh
 jx create addon anchore
 ```
 
-This will launch the require engine and services, and make it available to run on any of your teams environments, and on any running preview applications. 
+This will launch the require engine and services, and make it available to run on any of your teams environments, and on any running preview applications.
 
 To try it out, you can use the following command to report on any problems found:
 
-```
+```sh
 jx get cve --environment=staging
 ```
 
-Here is a video [showing it in action](https://youtu.be/rB8Sw0FqCQk). To remove this addon: 
+Here is a video [showing it in action](https://youtu.be/rB8Sw0FqCQk). To remove this addon:
 
-```
+```sh
 jx delete addon anchore
 ```
 
@@ -37,32 +37,30 @@ jx delete addon anchore
 
 ### Dynamic security
 
-The Open Web Application Security Project publishes a tool called ZAP: the [Zed Attack Proxy](https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project). This provides various tools including a baseline command that can be run against an application endpoint looking for a base set of problems. 
+The Open Web Application Security Project publishes a tool called ZAP: the [Zed Attack Proxy](https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project). This provides various tools including a baseline command that can be run against an application endpoint looking for a base set of problems.
 
-In Jenkins X this can be run against a Preview Application (that each application gets) by creating a post-preview hook: 
+In Jenkins X this can be run against a Preview Application (that each application gets) by creating a post-preview hook:
 
-```
+```sh
 jx create addon owasp-zap
-
 ```
 
-Any pull requests will then have their preview application run through the ZAP baseline scan, and should any failures be detected it will fail the CI pipeline automatically. The pipelines do not be changed to run this test, and they will apply to all pull requests for the team. 
+Any pull requests will then have their preview application run through the ZAP baseline scan, and should any failures be detected it will fail the CI pipeline automatically. The pipelines do not be changed to run this test, and they will apply to all pull requests for the team.
 
-To remove the ZAP test: 
+To remove the ZAP test:
 
-```
+```sh
 jx delete post preview job --name owasp-zap
-
 ```
 
-The post preview hook can also be configured with a command like: 
+The post preview hook can also be configured with a command like:
 
-```
+```sh
 jx create post preview job --name owasp --image owasp/zap2docker-weekly:latest -c "zap-baseline.py" -c "-I" -c "-t" -c "\$(JX_PREVIEW_URL)"
 ```
 
-You can have multiple hooks configured, so if you had specific containers that had probes/tests you would like to run against every preview app (ie every pull request) you could add it this way. 
+You can have multiple hooks configured, so if you had specific containers that had probes/tests you would like to run against every preview app (ie every pull request) you could add it this way.
 
 
-[Preview Environments](/developing/preview) 
+[Preview Environments](/developing/preview)
 

--- a/content/en/docs/managing-jx/common-tasks/storage.md
+++ b/content/en/docs/managing-jx/common-tasks/storage.md
@@ -19,12 +19,12 @@ So we've added a storage extension point which is used from:
 
 ## Configuring Storage
 
-You can setup the default location to use for storage. We currently support: 
+You can setup the default location to use for storage. We currently support:
 
 * storing files (logs, test or coverage reports) in a branch of a git repository. e.g. they could be part of your `gh-pages` branch for your static site.
 * storing files in Cloud Storage buckets like S3, GCS, Azure blobs etc
 
-Storage uses classifications which are used to define the folder in which the kind of resources live such as 
+Storage uses classifications which are used to define the folder in which the kind of resources live such as
 
 * logs
 * tests
@@ -39,30 +39,30 @@ Otherwise to configure the storage location for a classification and team you us
 
 e.g.
 
-```shell 
+```sh
 # Configure the tests to be stored in cloud storage (using S3 / GCS / Azure Blobs etc)
 jx edit storage -c tests --bucket-url s3://myExistingBucketName
-  
+
 # Configure the git URL and branch of where to store logs
 jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git --git-branch cheese
 ```
 
 You can view your teams storage settings via [jx get storage](/commands/jx_get_storage/)
-   
+
 
 ## Using Stash
 
 Inside a pipeline you can then run the [jx step stash](/commands/jx_step_stash/) command to stash files:
 
-```shell 
+```sh
 # lets collect some files with the file names relative to the 'target/test-reports' folder and store in a Git URL
-jx step stash -c tests -p "target/test-reports/*" --basedir target/test-reports 
+jx step stash -c tests -p "target/test-reports/*" --basedir target/test-reports
 
 # lets collect some files to a specific AWS cloud storage bucket
 jx step stash -c coverage -p "build/coverage/*" --bucket-url s3://my-aws-bucket
 ```
 
-* specify the `classifier` via `-c` such as for `tests` or `coverage` etc. 
+* specify the `classifier` via `-c` such as for `tests` or `coverage` etc.
 * specify the files to collect via `-p` which supports wildcards like `*`. files which will be stored with the relative directory path
 * if you want to remove a direectory prefix from the stashed files, like `target/reports` you can use `--basedir` to specify the directory to create relative file names from
 
@@ -79,6 +79,6 @@ If you are in some Go source code and you have a URL from Jenkins X, such as a B
   * `azblob://thatBucket/mydir/something.txt` : using an Azure bucket
   * `http://foo/bar` : file stored in git not using HTTPS
   * `https://foo/bar` : file stored in a git repo using HTTPS
-   
+
 
 If you want to easily be able to read from the URL from Go source code you can use the [`ReadURL` function](https://github.com/jenkins-x/jx/blob/e5a7943dc0c3d79c27f30aea73235f18b3f5dcff/pkg/cloud/buckets/buckets.go#L44-L45).

--- a/content/en/docs/managing-jx/faq/_index.md
+++ b/content/en/docs/managing-jx/faq/_index.md
@@ -3,7 +3,7 @@ title: FAQ
 linktitle: FAQ
 description: Questions about managing Jenkins X
 weight: 60
-aliases: 
+aliases:
   - /faq/setup/
 ---
 
@@ -51,16 +51,16 @@ If anything ever goes wrong (e.g. your cluster, namespace or tekton gets deleted
 Otherwise the older approach is as follows:
 
 ### If not using boot
- 
+
 You can upgrade via the [jx upgrade](/commands/jx_upgrade/) commands. Start with
 
-```shell
+```sh
 jx upgrade cli
 ```
 
 to get you on the latest CLI then you can upgrade the platform:
 
-```shell
+```sh
 jx upgrade platform
 ```
 
@@ -68,7 +68,7 @@ jx upgrade platform
 
 We use specific `BuildTemplates` for different programming languages. These `BuildTemplates` describe the steps that will be executed as part of the job, which in case of the Jenkins X BuildTemplates, they all execute the `JenkinsfileRunner` to execute the project's Jenkinsfile.
 
-```
+```sh
 $ kubectl get buildtemplates
 NAME                        AGE
 environment-apply           9d
@@ -102,20 +102,20 @@ The docker image that has the `Jenkinsfile` runner has also other tools installe
 
 Once this is done, you need to change the BuildTemplate in your cluster so that it starts using the new version of the docker image. For example, you can see the current version of this image for the Go BuildTemplate in your cluster
 
-```
+```sh
 $ kubectl describe buildtemplate jenkins-go | grep Image
 Image:       jenkinsxio/jenkins-go:256.0.44
 ```
 
 If you want to use a different version that uses a newer jx version you could manually change all the BuildTemplates but instead let's jx take care of it
 
-```
-$ jx upgrade addon jx-build-templates
+```sh
+jx upgrade addon jx-build-templates
 ```
 
 Check that the change has been done
 
-```
+```sh
 $ kubectl describe buildtemplate jenkins-go | grep Image
 Image:       jenkinsxio/jenkins-go:256.0.50
 ```
@@ -133,7 +133,7 @@ The [jx install](/commands/jx_install/) command takes a number of CLI arguments 
 
 We do recommend you use the default ingress controller if you can - as we know it works really well and only uses a single LoadBalancer IP for the whole cluster (your cloud provider often charges per IP address). However if you want to point at a different ingress controller just specify those arguments on install:
 
-```shell
+```sh
 jx install \
   --ingress-service=$(yoursvcname) \
   --ingress-deployment=$(yourdeployname) \

--- a/content/en/docs/managing-jx/faq/boot.md
+++ b/content/en/docs/managing-jx/faq/boot.md
@@ -4,7 +4,7 @@ linktitle: Boot Questions
 description: Questions on using 'jx boot'
 weight: 20
 aliases:
-  - /faq/issues/ 
+  - /faq/issues/
 ---
 
 For more detail check out how to use [jx boot](/docs/getting-started/setup/boot/).
@@ -24,12 +24,12 @@ Add more resources (e.g. `Ingress, ConfigMap, Secret`) to your development envir
 
 Add a new `SourceRepository` and `Environment` resource to the `env/templates` folder for each new environment you want tto create. We’ve only added `dev, staging, production` currently.
 
-From your running cluster you can always grab the staging `SourceRepository` and `Environment` resource via the following (where XXX is the name of the staging repository returned via `kubectl get sr`): 
+From your running cluster you can always grab the staging `SourceRepository` and `Environment` resource via the following (where XXX is the name of the staging repository returned via `kubectl get sr`):
 
-``` 
+```sh
 kubectl get env staging -oyaml > env/templates/myenv.yaml
 kubectl get sr XXX -oyaml > env/templates/myenv-sr.yaml
-```                 
+```
 
 then modify the YAML to suit, changing the names of the resources to avoid clashing with your staging repository.
 
@@ -42,7 +42,7 @@ See how to update your [boot configuration with the latest SourceRepository reso
 It depends on which namespace you want the charts to be installed.
 
 If its in the development environment (the `jx` namespace by default) then `env/requirements.yaml` is where to add the chart and for a chart `foo` you can add `env/foo/values.yaml` to configure it. (or `env/foo/values.tmpl.yaml` if you want to use some [templating](docs/getting-started/setup/boot/how-it-works/#improvements-to-values-yaml) of the `values.yaml`)
- 
+
 
 Though if you want our chart to be in another namespace then we use the convention of adding a folder in the `system` directory in the boot configuration (e.g. like we do for ingress, cert manager, velero, service mesh etc). So make a new folder in `system` and add the `jx step helm apply` step in the pipeline in `jenkins-x.yml` like we do for `cert-manager`, `nginx`, `velero` etc.
 

--- a/content/en/docs/managing-jx/faq/issues.md
+++ b/content/en/docs/managing-jx/faq/issues.md
@@ -4,7 +4,7 @@ linktitle: Common Problems
 description: Questions on common issues setting up Jenkins X.
 weight: 50
 aliases:
-  - /faq/issues/ 
+  - /faq/issues/
 ---
 
 We have tried to collate common issues here with work arounds. If your issue isn't listed here please [let us know](https://github.com/jenkins-x/jx/issues/new).
@@ -15,13 +15,13 @@ If your install fails to start there could be a few different reasons why the Je
 
 Your cluster could be out of resources. You can check the spare resources on your cluster via [jx status](/commands/jx_status/):
 
-```
+```sh
 jx status
 ```
 
 We also have a diagnostic command that looks for common problems [jx step verify install](/commands/jx_step_verify_install/):
 
-```
+```sh
 jx step verify install
 ```
 
@@ -29,13 +29,13 @@ A common issue for pods not starting is if your cluster does not have a [default
 
 You can check your storage class and persistent volume setup via:
 
-```
+```sh
 kubectl get pvc
 ```
 
 If things are working you should see something like:
 
-```
+```sh
 $ kubectl get pvc
 NAME                        STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
 jenkins                     Bound     pvc-680b39b5-94f1-11e8-b93d-42010a840238   30Gi       RWO            standard       12h
@@ -51,13 +51,13 @@ Please try create a [default storage class](https://kubernetes.io/docs/concepts/
 
 If the `Persistent Volume Claims` are all `Bound` and things still have not started then try
 
-```
+```sh
 kubectl get pod
 ```
 
 If a pod cannot start try
 
-```
+```sh
 kubectl describe pod some-pod-name
 ```
 
@@ -69,7 +69,7 @@ If you are still stuck try [create an issue](https://github.com/jenkins-x/jx/iss
 
 If your pipeline fails with something like this:
 
-```
+```sh
 The push refers to a repository [100.71.203.90:5000/lgil3/jx-test-app]
 time="2018-07-09T21:18:31Z" level=fatal msg="build step: pushing [100.71.203.90:5000/lgil3/jx-test-app:0.0.2]: Get https://100.71.203.90:5000/v1/_ping: http: server gave HTTP response to HTTPS client"
 ```
@@ -117,13 +117,13 @@ It basically happens if you have an old API token in `~/.jx/jenkinsAuth.yaml` fo
 
 If you see errors like:
 
-```
+```sh
 error:failed to add the repository 'jenkins-x' with URL 'https://chartmuseum.build.cd.jenkins-x.io'
 ```
 
 or
 
-```
+```sh
 Looks like "https://chartmuseum.build.cd.jenkins-x.io" is not a valid chart repository or cannot be reached
 ```
 
@@ -133,7 +133,7 @@ The new URL is: http://chartmuseum.jenkins-x.io
 
 It could be your helm install has an old repository URL installed. You should see...
 
-```
+```sh
 $ helm repo list
 NAME     	URL
 stable   	https://kubernetes-charts.storage.googleapis.com
@@ -142,7 +142,7 @@ jenkins-x	http://chartmuseum.jenkins-x.io
 
 If you see this...
 
-```
+```sh
 $ helm repo list
 NAME     	URL
 jenkins-x	https://chartmuseum.build.cd.jenkins-x.io
@@ -150,7 +150,7 @@ jenkins-x	https://chartmuseum.build.cd.jenkins-x.io
 
 then please run...
 
-```
+```sh
 helm repo remove jenkins-x
 helm repo add jenkins-x	http://chartmuseum.jenkins-x.io
 ```
@@ -168,7 +168,7 @@ This indicates your git API token either was input incorrectly or has been regen
 
 To recreate it with a new API token value try the following (changing the git server name to match your git provider):
 
-```
+```sh
 jx delete git token -n GitHub admin
 jx create git token -n GitHub admin
 ```
@@ -180,7 +180,7 @@ More details on [using git and Jenkins X here](/docs/managing-jx/common-tasks/gi
 
 If you get an error in Jenkins when it tries to scan your repositories for branches something like:
 
-```
+```sh
 hudson.AbortException: Invalid scan credentials *****/****** (API Token for acccessing https://github.com git service inside pipelines) to connect to https://api.github.com, skipping
 ```
 
@@ -188,7 +188,7 @@ Then your git API token was probably wrong or has expired.
 
 To recreate it with a new API token value try the following (changing the git server name to match your git provider):
 
-```
+```sh
 jx delete git token -n GitHub admin
 jx create git token -n GitHub admin
 ```
@@ -225,13 +225,13 @@ The you should check that you have a cluster default storage class for dynamic p
 
 If you don't see any valid nodes returned by `kubectl get node` or you get errors running `jx status` something like:
 
-```
+```sh
 Unable to connect to the server: dial tcp: lookup abc.def.regino.eks.amazonaws.com on 10.0.0.2:53: no such host
 ```
 
 it could be your kube config is stale. Try
 
-```
+```sh
 aws eks --region <CLUSTER_REGION> update-kubeconfig --name <CLUSTER_NAME>
 ```
 
@@ -249,7 +249,7 @@ One way to diagnose logs in your, say, Staging environment is to [download and i
 
 Then run this command:
 
-```shell
+```sh
 kail -l job-name=expose -n jx-staging
 ```
 
@@ -260,7 +260,7 @@ If you then promote to the Staging environment or retrigger the pipeline on the 
 
 If you find you get lots of warnings in your pipelines like this...
 
-```
+```sh
 "Failed to query the Pull Request last commit status for https://github.com/myorg/environment-mycluster-staging/pull/1 ref xyz Could not find a status for repository myorg/environment-mycluster-staging with ref xyz
 ```
 
@@ -272,7 +272,7 @@ However sometimes your git provider (e.g. [GitHub](https://github.com/) may not 
 
 The easiest way to diagnose this is opening the git repository (e.g. for your environment repository).
 
-```
+```sh
 jx get env
 ```
 
@@ -292,12 +292,16 @@ If you are using a Mac then `hyperkit` is the best VM driver to use - but does r
 
 If your minikube is failing to startup then you could try:
 
-    minikube delete
-    rm -rf ~/.minikube
+```sh
+minikube delete
+rm -rf ~/.minikube
+```
 
 If the `rm` fails you may need to do:
 
-    sudo rm -rf ~/.minikube
+```sh
+sudo rm -rf ~/.minikube
+```
 
 Now try `jx create cluster minikube` again - did that help? Sometimes there are stale certs or files hanging around from old installations of minikube that can break things.
 
@@ -312,7 +316,7 @@ Otherwise you could try follow the minikube instructions
 
 If you are using minikube on a mac with hyperkit and find minikube fails to start with a log like:
 
-```
+```sh
 Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
 Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
 Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
@@ -323,7 +327,7 @@ It could be you have hit [this issue in minikube and hyperkit](https://github.co
 
 The work around is to try the following:
 
-```
+```sh
 rm ~/.minikube/machines/minikube/hyperkit.pid
 ```
 
@@ -350,7 +354,7 @@ Then re-run `jx install` and this will switch the services to be exposed on `nod
 
 So if you type:
 
-```
+```sh
 jx open
 ```
 
@@ -373,7 +377,7 @@ If you want to view the logs of the `exposecontroller` you will need to watch fo
 One way to do that is via the [kail](https://github.com/boz/kail) CLI:
 
 
-```
+```sh
 kail -l  job-name=expose
 ```
 
@@ -385,7 +389,7 @@ This will watch for exposecontroller logs and then dump them to the console. Now
 
 Newly created GKE clusters or existing cluster running _kubernetes_ **v1.12** or older will encounter the following error when configuring Ingress with site-wide TLS:
 
-```
+```sh
 Waiting for TLS certificates to be issued...
 Timeout reached while waiting for TLS certificates to be ready
 ```
@@ -393,17 +397,17 @@ Timeout reached while waiting for TLS certificates to be ready
 This issue is caused by the _cert-manager_ pod not having the `disable-validation` label set, which is a known cert-manager issue which is [documented on their website](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html). The following steps, taken from the [cert-manager/troubleshooting-installation](https://docs.cert-manager.io/en/latest/getting-started/troubleshooting.html#troubleshooting-installation) webpage, should resolve the issue:
 
 Check if the _disable-validation_ label exists on the _cert-manager_ pod.
-```
+```sh
 kubectl describe namespace cert-manager
 ```
 
 If you cannot see the `certmanager.k8s.io/disable-validation=true` label on your namespace, you should add it with:
-```
+```sh
 kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 ```
 
 Confirm the label has been added to the _cert-manager_ pod.
-```
+```sh
 kubectl describe namespace cert-manager
 
 Name:         cert-manager
@@ -414,17 +418,17 @@ Status:       Active
 ```
 
 Now rerun _jx_ Ingress setup:
-```
+```sh
 jx upgrade ingress
 ```
 
 While the ingress command is running, you can tail the _cert-manager_ logs in another terminal and see what is happening. You will need to find the name of your _cert-manager_ pod using:
-```
+```sh
 kubectl get pods --namespace cert-manager
 ```
 
 Then tail the logs of the _cert-manager_ pod.
-```
+```sh
 kubectl logs YOUR_CERT_MNG_POD --namespace cert-manager -f
 ```
 

--- a/content/en/docs/managing-jx/old/config.md
+++ b/content/en/docs/managing-jx/old/config.md
@@ -52,12 +52,12 @@ chartmuseumServiceLink:
 
 ## Jenkins Image
 
-We ship with a default Jenkins docker image [jenkinsxio/jenkinsx](https://hub.docker.com/r/jenkinsxio/jenkinsx/) with Jenkins X which has all of our required plugins inside. 
+We ship with a default Jenkins docker image [jenkinsxio/jenkinsx](https://hub.docker.com/r/jenkinsxio/jenkinsx/) with Jenkins X which has all of our required plugins inside.
 
 If you wish to add your own plugins you can create your own `Dockerfile` and image using our base image like this:
 
-```
-# Dockerfile for adding plugins to Jenkins X 
+```dockerfile
+# Dockerfile for adding plugins to Jenkins X
 FROM jenkinsxio/jenkinsx:latest
 
 COPY plugins.txt /usr/share/jenkins/ref/openshift-plugins.txt
@@ -66,7 +66,7 @@ RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/openshift-plugins
 
 Then add your custom plugins to `plugins.txt` locally of the form:
 
-``` 
+```txt
 myplugin:1.2.3
 anotherplugin:4.5.6
 ```
@@ -74,7 +74,7 @@ anotherplugin:4.5.6
 Once you have built and released your image via CI/CD you can then use it in your Jenkins X installation.
 
 To configure Jenkins X to use your custom image you can specify your own Jenkins image via a `myvalues.yaml` file:
-  
+
 ```yaml
 jenkins:
   Master:
@@ -86,14 +86,14 @@ There is an example OSS project [jenkins-x/jenkins-x-openshift-image](https://gi
 
 ## Docker Registry
 
-We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS. 
+We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS.
 
 However you can also specify this via the `--docker-registry` option when running  [jx create cluster](/commands/jx_create_cluster) or [jx install](/commands/jx_install)
 
 e.g.
 
-``` 
+```sh
 jx create cluster gke --docker-registry eu.gcr.io
-```   
+```
 
 Though if you use a different Docker Registry you will probably need to [also modify the secret for connecting to docker](/docs/managing-jx/common-tasks/docker-registry/#update-the-config-json-secret).

--- a/content/en/docs/managing-jx/old/create-cluster.md
+++ b/content/en/docs/managing-jx/old/create-cluster.md
@@ -49,20 +49,22 @@ First you need to open the Google Cloud Shell via the button in the toolbar:
 
 Then you need to download the `jx` binary:
 
-```shell
+```sh
 curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Site.Params.release}}/jx-linux-amd64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```
 
 Now use the [jx create cluster gke](/commands/jx_create_cluster_gke) command:
 
-    jx create cluster gke --skip-login
-
+```sh
+jx create cluster gke --skip-login
+```
 
 If you wish to name your cluster and provide your own admin password you can run:
 
-    jx create cluster gke --skip-login  --default-admin-password=mySecretPassWord123 -n myclustername
-
+```sh
+jx create cluster gke --skip-login  --default-admin-password=mySecretPassWord123 -n myclustername
+```
 
 ## The `jx create cluster gke` process
 
@@ -75,7 +77,9 @@ browser.
     In this example, the Google Kubernetes Engine is used as the
     Kubernetes provider:
 
-        jx create cluster gke
+```sh
+jx create cluster gke
+```
 
 2.  The installation is interactive, stepping you through the entire
     installation and configuration of the Kubernetes cluster creation
@@ -191,16 +195,18 @@ You should now be able to use the `kubectl` and `jx` CLI tools on your laptop to
 
 Use the [jx create cluster gke](/commands/jx_create_cluster_gke) command:
 
-    jx create cluster gke --verbose
+```sh
+jx create cluster gke --verbose
+```
 
 Or if you are already logged in by previously using `gcloud init` or `gcloud auth login`:
 
-    jx create cluster gke --skip-login --verbose
+```sh
+jx create cluster gke --skip-login --verbose
+```
 
 Those commands assume you have a google account and you've set up a default project that you can use to create the kubernetes cluster within.
 Now **[develop apps faster with Jenkins X](/docs/getting-started/next/)**.
-
-
 
 ## Using Amazon (AWS)
 
@@ -218,7 +224,7 @@ Using wildcard DNS pointing to your ELB/NLB also means you'll be able to use all
 
 The `jx` command will ask you if you want to automate the setup fo the Route 53 wildcard CNAME. If you want to do it yourself you need to point to the ELB host name defined via:
 
-```
+```sh
 kubectl get service -n kube-system jxing-nginx-ingress-controller  -oyaml | grep hostname
 ```
 
@@ -237,16 +243,19 @@ Note if you wish to use a different git provider than GitHub for your environmen
 
 Use the [jx create cluster eks](/commands/jx_create_cluster_eks) command:
 
-    jx create cluster eks
+```sh
+jx create cluster eks
+```
 
 Under the covers this will download and use the [eksctl](https://eksctl.io/) tool to create a new EKS cluster, then it'll install Jenkins X on top.
-
 
 ### Kops
 
 Use the [jx create cluster aws](/commands/jx_create_cluster_aws) command:
 
-    jx create cluster aws
+```sh
+jx create cluster aws
+```
 
 This will use [kops](https://github.com/kubernetes/kops) on your Amazon account to create a new kubernetes cluster and install Jenkins X.
 
@@ -254,7 +263,7 @@ To try this out we recommend you follow the [AWS Workshop for Kubernetes](https:
 
 Then create a new terminal in Cloud9 and try these commands:
 
-```shell
+```sh
 curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Site.Params.release}}/jx-linux-amd64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 jx create cluster aws
@@ -262,23 +271,25 @@ jx create cluster aws
 
 Now **[develop apps faster with Jenkins X](/docs/getting-started/next/)**.
 
-
 ## Using Azure (AKS)
 
 Before you start you may find [this blog helpful](https://cloudblogs.microsoft.com/opensource/2019/03/06/jenkins-x-azure-kubernetes-service-setup/).
 
 Use the [jx create cluster aks](/commands/jx_create_cluster_aks) command:
 
-    jx create cluster aks
+```sh
+jx create cluster aks
+```
 
 Now **[develop apps faster with Jenkins X](/docs/getting-started/next/)**.
-
 
 ## Using Oracle (OKE)
 
 Use the [jx create cluster oke](/commands/jx_create_cluster_oke) command:
 
-    jx create cluster oke
+```sh
+jx create cluster oke
+```
 
 This will use [oci](https://github.com/oracle/oci-cli) on your Oracle Cloud Infrastructure account to create a new OKE cluster and install Jenkins X.
 
@@ -290,7 +301,9 @@ Now **[develop apps faster with Jenkins X](/docs/getting-started/next/)**.
 
 Use the [jx create cluster iks](/commands/jx_create_cluster_iks) command:
 
-    jx create cluster iks --apikey=<IBM Cloud API Key>
+```sh
+jx create cluster iks --apikey=<IBM Cloud API Key>
+```
 
 This will use [IBM Cloud CLI](https://console.bluemix.net/docs/cli/index.html#overview) on your IBM Cloud Infrastructure account to create a new IKS cluster and install Jenkins X.
 
@@ -311,7 +324,9 @@ So we **highly** recommend using one of the public clouds above to try out Jenki
 
 If you still want to try minikube then we recommend letting jx create the cluster for you (as opposed to installing jx into an existing minikube cluster) by running:
 
-    jx create cluster minikube
+```sh
+jx create cluster minikube
+```
 
 You'll be prompted for the amount of memory, cores, and disk size to use, and also the driver.
 
@@ -319,7 +334,7 @@ A known good configuration on a 2015 model Macbook Pro is to use 8 GB of RAM, 8 
 
 The disk size is particularly large as a number of images will need to be downloaded. These are used by jx and here are the sizes at the time of this document:
 
-```
+```sh
 jxpv1                           8Gi        RWO            Recycle          Bound       jx/jenkins-x-nexus                                                               5d
 jxpv2                           100Gi      RWO            Recycle          Bound       jx/jenkins-x-docker-registry                                                     6d
 jxpv3                           8Gi        RWO            Recycle          Bound       jx/jenkins-x-mongodb                                                             22h
@@ -348,10 +363,11 @@ If you want to try out Jenkins X on a local OpenShift cluster then you can try u
 
 To create a minishift VM with Jenkins X installed on it try the [jx create cluster minishift](/commands/jx_create_cluster_minishift) command:
 
-    jx create cluster minishift
+```sh
+jx create cluster minishift
+```
 
 Now **[develop apps faster with Jenkins X](/docs/getting-started/next/)**.
-
 
 ## Troubleshooting
 

--- a/content/en/docs/managing-jx/old/install-on-cluster.md
+++ b/content/en/docs/managing-jx/old/install-on-cluster.md
@@ -85,7 +85,7 @@ Note that you may want to use the [jx create cluster aws](/docs/getting-started/
 
 Do the following:
 
-```
+```sh
 kops edit cluster
 ```
 
@@ -107,7 +107,7 @@ spec:
 
 Now to make this change active on your cluster type:
 
-```
+```sh
 kops update cluster --yes
 ```
 
@@ -118,7 +118,7 @@ You should now be good to go!
 
 Do the following:
 
-```
+```sh
 kops edit cluster
 ```
 
@@ -136,7 +136,7 @@ That IP range, `100.64.0.0/10`, works on AWS, but you may need to change it on o
 
 Then save the changes. You can verify your changes via:
 
-```
+```sh
 kops get cluster -oyaml
 ```
 
@@ -144,7 +144,7 @@ and looking for the `insecureRegistry` section.
 
 Now to make this change active on your cluster type:
 
-```
+```sh
 kops update cluster --yes
 kops rolling-update cluster --yes
 ```
@@ -155,11 +155,15 @@ You should now be good to go!
 
 To install Jenkins X on an existing Kubernetes cluster, you can then use the [jx install](/commands/jx_install) command:
 
-    jx install
+```sh
+jx install
+```
 
 If you know the provider, you can specify the provider on the command line. e.g.
 
-    jx install --provider=aws
+```sh
+jx install --provider=aws
+```
 
 Note: if you wish to use a different Git provider than GitHub for your environments, see [how to use a different Git provider](/docs/managing-jx/common-tasks/git/#using-a-different-git-provider-for-environments)
 
@@ -172,29 +176,37 @@ __Prerequisits__
 
 When using an on premise Kubernetes cluster, you can use this command line:
 
-    jx install --provider=kubernetes --on-premise
+```sh
+jx install --provider=kubernetes --on-premise
+```
 
 This will default the argument for `--external-ip` to access services inside your cluster to use the Kubernetes master IP address.
 
 If you wish to use a different external IP address, you can use:
 
-    jx install --provider=kubernetes --external-ip 1.2.3.4
+```sh
+jx install --provider=kubernetes --external-ip 1.2.3.4
+```
 
-Otherwise, the `jx install` will try and wait for the Ingress Controllers `Service.Status.LoadBalancer.Ingress` to resolve to an IP address - which can fail on premise.   
+Otherwise, the `jx install` will try and wait for the Ingress Controllers `Service.Status.LoadBalancer.Ingress` to resolve to an IP address - which can fail on premise.
 
 If you already have an ingress controller installed, then try:
 
-    jx install --provider=kubernetes \
-    --skip-ingress \
-    --external-ip=10.20.30.40 \
-    --domain=10.20.30.40.nip.io
+```sh
+jx install --provider=kubernetes \
+  --skip-ingress \
+  --external-ip=10.20.30.40 \
+  --domain=10.20.30.40.nip.io
+```
 
 If you do not know the domain or want it extracted from your Ingress deployment, try
 
-    jx install --provider=kubernetes --external-ip 10.123.0.17 \
-    --ingress-service=$(yoursvcname) \
-    --ingress-deployment=$(yourdeployname) \
-    --ingress-namespace=kube-system
+```sh
+jx install --provider=kubernetes --external-ip 10.123.0.17 \
+  --ingress-service=$(yoursvcname) \
+  --ingress-deployment=$(yourdeployname) \
+  --ingress-namespace=kube-system
+```
 
 If you want an explanation of what the [jx install](/commands/jx_install) command does, you can read [what happens with the install](../install-on-cluster-what-happens)
 
@@ -206,7 +218,7 @@ __Prerequisites__
 
 IBM Cloud Private includes a Docker registry and ingress controller. You can install Jenkins X into IBM Cloud Private with the following command:
 
-```
+```sh
 jx install --provider=icp
 ```
 
@@ -214,7 +226,7 @@ The installation process prompts for the master IP address in your Kubernetes cl
 
 Create `ClusterImagePolicies` on IBM Cloud Private version 3.1.0 and set the following permissions:
 
-```
+```txt
 - name: docker.io/*
 - name: gcr.io/*
 - name: quay.io/*

--- a/content/en/docs/managing-jx/old/manage-via-gitops.md
+++ b/content/en/docs/managing-jx/old/manage-via-gitops.md
@@ -14,9 +14,9 @@ We recommend you use GitOps to manage your installation of Jenkins X, to upgrade
 
 Currently this only works on AWS and Google cloud as it requires our vault operator (which needs cloud storage & KMS) to store secrets while all other configuration is stored in the development environment git repository.
 
-## Using GitOps to manage Jenkins X 
+## Using GitOps to manage Jenkins X
 
-If you are creating a cluster or installing on an existing cluster there is a quick and handy way to use GitOps to manage Jenkins X itself - it’s `—ng` for the next generation of Jenkins X. We’ll make this feature flags options the default when we release 2.x of Jenkins X later this year. 
+If you are creating a cluster or installing on an existing cluster there is a quick and handy way to use GitOps to manage Jenkins X itself - it’s `—ng` for the next generation of Jenkins X. We’ll make this feature flags options the default when we release 2.x of Jenkins X later this year.
 
 
 The `—ng` flag is an alias for these flags: `—gitops —vault —no-tiller —tekton`. So it also comes with baked in support for [Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) - the modern cloud native pipeline engine based on Tekton.
@@ -30,10 +30,10 @@ Once you have installed Jenkins X using GitOps to manage the dev environment- th
 
 Generally speaking Jenkins X can upgrade itself quite easily when using tekton. However if an upgrade breaks Jenkins X from implementing CI/CD then the GitOps to revert the change won’t work ;)
 
-if you hit any issues upgrading Jenkins X there is a manual way to apply the contents of the development environment’s git repository 
+if you hit any issues upgrading Jenkins X there is a manual way to apply the contents of the development environment’s git repository
 
-``` 
+```sh
 git clone $MY_DEV_GIT_CLONE_URL jenkins-x-dev-env
 cd jenkins-x-dev-env/env
-jx step env apply 
+jx step env apply
 ```

--- a/content/en/docs/managing-jx/tutorials/install-gke-with-bot-tutorial.md
+++ b/content/en/docs/managing-jx/tutorials/install-gke-with-bot-tutorial.md
@@ -3,7 +3,7 @@ title: "Install Jenkins X on GKE Properly"
 linkTitle: "Install Jenkins X on GKE"
 date: 2019-04-25T07:36:00+02:00
 description: >
-   A comprehensive tutorial on how to install and configure Jenkins X so that you have a Jenkins X Bot working properly.  This ensures your experience as a Developer interacting with Jenkinx X is more realistic.  
+   A comprehensive tutorial on how to install and configure Jenkins X so that you have a Jenkins X Bot working properly.  This ensures your experience as a Developer interacting with Jenkinx X is more realistic.
 categories: [blog]
 keywords: [jenkins-x-bot,GKE,Install,Tutorial]
 slug: "jenkins-x-gke-install-with-bot"
@@ -14,7 +14,7 @@ weight: 20
 
 **NOTE:** This tutorial is based on the following jx version
 
-```cmd
+```sh
     NAME               VERSION
     jx                 2.0.33
     jenkins x platform 2.0.108
@@ -23,7 +23,7 @@ weight: 20
     helm client        Client: v2.13.1+g618447c
     git                git version 2.21.0
     Operating System   Mac OS X 10.14.3 build 18D42
-```  
+```
 
 # Overview
 In this tutorial, we walk you through a full setup of Jenkinx X in GKE, including setup of the Bot.  We will install Jenkins X Serverless topology which also brings Tekton pipelines for us to use in this scenario.  We walk through putting an app via CI/CD and ensuring the Jenkins X Bot is working as expected.
@@ -39,7 +39,7 @@ In this tutorial, we walk you through a full setup of Jenkinx X in GKE, includin
 **NOTE:**  If you've provisioned the cluster using Terraform, this should still work.  However you cannot run the command we outline below, instead you will have to run the `jx install --ng=true` command.
 {{% /alert %}}
 
-# Prerequisites 
+# Prerequisites
 
 1. A GCP account along with a **Project** already created.
 2. You should be able to create resources via the `gcloud` CLI
@@ -67,8 +67,8 @@ Your Github Organization and user accounts should be setup similar to how it is 
 ## Creating GKE Cluster and Installing Jenkins X
 The first step we need to take, is execute the command which simultaneously will provision a cluster and install Jenkins X.  The following command should be issued on the terminal.  Change placeholders accordingly.
 
-```bash
-> $ jx create cluster gke --default-admin-password=<YOURPASSWORD> -n <CLUSTERNAME> --ng=true
+```sh
+jx create cluster gke --default-admin-password=<YOURPASSWORD> -n <CLUSTERNAME> --ng=true
 ```
 
 {{% alert %}}
@@ -78,7 +78,7 @@ The first step we need to take, is execute the command which simultaneously will
 ## Output of the Command - lengthy but let's break it down!
 The output below is quite insightful, we include it here for you to see all of what happens as the install is happening.
 
-```bash
+```sh
 
 Using the only Google Cloud Project jenkinsx-dev to create the cluster
 Updated property [core/project].
@@ -95,8 +95,8 @@ No apis to enable
 Creating cluster...
 Initialising cluster ...
 Setting the dev namespace to: jx
-Namespace jx created 
- 
+Namespace jx created
+
 Using helmBinary helm with feature flag: none
 Context "gke_jenkinsx-dev_us-west1-a_sposcar" modified.
 Storing the kubernetes provider gke in the TeamSettings
@@ -108,20 +108,20 @@ Created ClusterRoleBinding omedina-cloudbees-com-cluster-admin-binding
 Using helm2
 Skipping tiller
 ```
+
 ### Key Things happened above...
-- Basic cluster configuration such as max and min nodes are configured.  
+- Basic cluster configuration such as max and min nodes are configured.
 - Kubectl context is set to new cluster so you can access cluster via both `kubectl` and `jx`
 - Sets cluster admin via ClusterRoleBinding created
 
-```bash
-
+```sh
 Using helmBinary helm with feature flag: template-mode
 Initialising Helm 'init --client-only'
 helm installed and configured
 ? No existing ingress controller found in the kube-system namespace, shall we install one? Yes
 
 Current configuration dir: /Users/omedina/.jx
-versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref: 
+versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref:
 Deleting and cloning the Jenkins X versions repo
 Cloning the Jenkins X versions repo https://github.com/jenkins-x/jenkins-x-versions.git with ref refs/heads/master to /Users/omedina/.jx/jenkins-x-versions
 Enumerating objects: 206, done.
@@ -131,7 +131,7 @@ Total 1096 (delta 109), reused 185 (delta 101), pack-reused 890
 using stable version 1.3.1 from charts of stable/nginx-ingress from /Users/omedina/.jx/jenkins-x-versions
 Installing using helm binary: helm
 Current configuration dir: /Users/omedina/.jx
-versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref: 
+versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref:
 Deleting and cloning the Jenkins X versions repo
 Cloning the Jenkins X versions repo https://github.com/jenkins-x/jenkins-x-versions.git with ref refs/heads/master to /Users/omedina/.jx/jenkins-x-versions
 Enumerating objects: 206, done.
@@ -164,11 +164,12 @@ If you do not have a custom domain setup yet, Ingress rules will be set for magi
 
 Once you have a custom domain ready, you can update with the command jx upgrade ingress --cluster
 ```
+
 {{% alert %}}
 At this point, we have already set our DNS settings to point to the IP listed above for the ingress controller and gave it a bit of time to propagate before hitting **enter** `sharepointoscar.com` for the Domain, and letting it configure ingress and other endpoints.
 {{% /alert %}}
 
-```bash
+```sh
 If you don't have a wildcard DNS setup then setup a DNS (A) record and point it at: 34.83.54.46 then use the DNS domain in the next input...
 ? Domain sharepointoscar.com
 nginx ingress controller installed and configured
@@ -180,7 +181,7 @@ Select the CI/CD pipelines Git server and user
 Setting the pipelines Git server https://github.com and user name jenkinsx-bot-sposcar.
 Saving the Git authentication configuration
 Current configuration dir: /Users/omedina/.jx
-versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref: 
+versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref:
 Deleting and cloning the Jenkins X versions repo
 Cloning the Jenkins X versions repo https://github.com/jenkins-x/jenkins-x-versions.git with ref refs/heads/master to /Users/omedina/.jx/jenkins-x-versions
 Enumerating objects: 206, done.
@@ -199,16 +200,15 @@ Cloning the Jenkins X cloud environments repo to /Users/omedina/.jx/cloud-enviro
 Enumerating objects: 1382, done.
 Total 1382 (delta 0), reused 0 (delta 0), pack-reused 1382
 ? Select Jenkins installation type: Serverless Jenkins X Pipelines with Tekton
-
 ```
+
 ### Key Things happened above...
 - We specified `sharepointoscar.com` as the domain for the ingress controller and endpoints.
 - GitHub server account is set to `jenkinsx-bot-sposcar` and which is part of the Organization `jenkins-oscar`
 - We were prompted to enter an **API token** for the bot account **(we are signed into Github with the bot account)**
 - Jenkins Installation Type is set to **Serverless Jenkins X Pipelines with Tekton**
 
-
-```bash
+```sh
 Configuring Kaniko service account jxkaniko-sposcar for project jenkinsx-dev
 Unable to find service account jxkaniko-sposcar, checking if we have enough permission to create
 Creating service account jxkaniko-sposcar
@@ -225,7 +225,7 @@ Setting the current namespace to: jx
 
 Installing knative into namespace jx
 Current configuration dir: /Users/omedina/.jx
-versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref: 
+versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref:
 Deleting and cloning the Jenkins X versions repo
 Cloning the Jenkins X versions repo https://github.com/jenkins-x/jenkins-x-versions.git with ref refs/heads/master to /Users/omedina/.jx/jenkins-x-versions
 Enumerating objects: 206, done.
@@ -266,7 +266,7 @@ Removing Kubernetes resources from older releases using selector: jenkins.io/cha
 
 Installing Prow into namespace jx
 Current configuration dir: /Users/omedina/.jx
-versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref: 
+versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref:
 Deleting and cloning the Jenkins X versions repo
 Cloning the Jenkins X versions repo https://github.com/jenkins-x/jenkins-x-versions.git with ref refs/heads/master to /Users/omedina/.jx/jenkins-x-versions
 Enumerating objects: 206, done.
@@ -338,7 +338,7 @@ Adding values file /Users/omedina/.jx/adminSecrets.yaml
 Adding values file /Users/omedina/.jx/extraValues.yaml
 Adding values file /Users/omedina/.jx/cloud-environments/env-gke/secrets.yaml
 Current configuration dir: /Users/omedina/.jx
-versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref: 
+versionRepository: https://github.com/jenkins-x/jenkins-x-versions.git git ref:
 Deleting and cloning the Jenkins X versions repo
 Cloning the Jenkins X versions repo https://github.com/jenkins-x/jenkins-x-versions.git with ref refs/heads/master to /Users/omedina/.jx/jenkins-x-versions
 Enumerating objects: 206, done.
@@ -489,7 +489,7 @@ Configuring the TeamSettings for ImportMode YAML
 
 	********************************************************
 
-	
+
 Creating default staging and production environments
 ? Select the organization where you want to create the environment repository: jenkins-oscar
 Using Git provider GitHub at https://github.com
@@ -504,8 +504,8 @@ Pushed Git repository to https://github.com/jenkins-oscar/environment-sposcar-st
 
 Creating staging Environment in namespace jx
 Created environment staging
-Namespace jx-staging created 
- 
+Namespace jx-staging created
+
 Creating GitHub webhook for jenkins-oscar/environment-sposcar-staging for url http://hook.jx.sharepointoscar.com/hook
 Using Git provider GitHub at https://github.com
 
@@ -519,8 +519,8 @@ Pushed Git repository to https://github.com/jenkins-oscar/environment-sposcar-pr
 
 Creating production Environment in namespace jx
 Created environment production
-Namespace jx-production created 
- 
+Namespace jx-production created
+
 Creating GitHub webhook for jenkins-oscar/environment-sposcar-production for url http://hook.jx.sharepointoscar.com/hook
 
 Jenkins X installation completed successfully
@@ -532,9 +532,9 @@ Jenkins X installation completed successfully
 
 	********************************************************
 
-	
 
-Your Kubernetes context is now set to the namespace: jx 
+
+Your Kubernetes context is now set to the namespace: jx
 To switch back to your original namespace use: jx namespace default
 Or to use this context/namespace in just one terminal use: jx shell
 For help on switching contexts see: https://jenkins-x.io/docs/using/tasks/kube-context/
@@ -566,7 +566,7 @@ So we now have a clean environment, one thing we can do to simply test our endpo
 
 We are ready to try out the entire CI/CD process, which includes seeing the Bot work properly.  To get started, we will create a `quickstart` based on the `NodeJS` language.
 
-```bash
+```sh
 > $ omedina$ jx create quickstart
 Using Git provider GitHub at https://github.com
 ? Git user name?  [Use arrows to move, space to select, type to filter]
@@ -574,7 +574,7 @@ Using Git provider GitHub at https://github.com
   jenkinsx-bot-sposcar
 
 ```
-You will select the personal Github account in this step.  
+You will select the personal Github account in this step.
 
 {{% alert color="warning" %}}
 However, if you get a *warning* message stating that the Github server username is not set, then the setup somehow was not set correctly.
@@ -587,7 +587,7 @@ You can verify that the bot account is setup by checking the values of the secre
 
 {{% /alert %}}
 
-```bash
+```sh
 About to create repository  on server https://github.com with user sharepointoscar
 ? Which organisation do you want to use?  [Use arrows to move, space to select, type to filter]
   SPRWD
@@ -598,7 +598,7 @@ About to create repository  on server https://github.com with user sharepointosc
 ```
 Select the Github Organization.  In this scenario, it is `jenkins-oscar` where the bot account and the personal github accounts are members.
 
-```bash
+```sh
 Creating repository jenkins-oscar/node-widget-app
 ? select the quickstart you wish to create  [Use arrows to move, space to select, type to filter]
   golang-http
@@ -612,12 +612,11 @@ Creating repository jenkins-oscar/node-widget-app
 The directory /Users/omedina/git-repos/node-widget-app is not yet using git
 ? Would you like to initialise git now? Yes
 ? Commit message:  Initial import
-
-
 ```
+
 Select `node-http` for the quickstart builder type. Hit enter for both of the following questions.
 
-```bash
+```sh
 replacing placeholders in directory /Users/omedina/git-repos/node-widget-app
 app name: node-widget-app, git server: github.com, org: jenkins-oscar, Docker registry org: jenkins-oscar
 skipping directory "/Users/omedina/git-repos/node-widget-app/.git"
@@ -635,19 +634,17 @@ When the pipeline is complete:  jx get applications
 For more help on available commands see: https://jenkins-x.io/docs/using/tasks/browsing/
 
 Note that your first pipeline may take a few minutes to start while the necessary images get downloaded!
-
 ```
 
 Final output from creating the Quickstart should look like above.
 
-
 ##  First Pipeline Run
-Since we just created the new app, if we check on the app activtiies, we will see that there is a pull request. `jx get activity -f node-widget-app -w` and the app is now version `0.0.1` and it has been deployed to our **Staging** environment.  
+Since we just created the new app, if we check on the app activtiies, we will see that there is a pull request. `jx get activity -f node-widget-app -w` and the app is now version `0.0.1` and it has been deployed to our **Staging** environment.
 
 ### Deployed to Staging
 
 We can also check what applications are deployed, we should have version `0.0.1` in our staging environment.
-```bash
+```sh
 APPLICATION        STAGING PODS URL
 jx-node-widget-app 0.0.1   1/1  http://node-widget-app.jx-staging.sharepointoscar.com
 jx-testapp2        0.0.2   1/1  http://testapp2.jx-staging.sharepointoscar.com
@@ -685,10 +682,9 @@ We can take a quick look at what the bot has been up to.  Here is all the activi
 
 <img src="/images/getting-started/bot_in_action.png">
 
-
 # Conclusion
 
-In this tutorial, we walked through a full setup of Jenkins X on GKE.  We ensured that the bot account was specified at setup time.  We then created an app, and put it through CI/CD which allowed us to see the Bot in action, execute an approval command and deploy the app changes to our Staging environment. 
+In this tutorial, we walked through a full setup of Jenkins X on GKE.  We ensured that the bot account was specified at setup time.  We then created an app, and put it through CI/CD which allowed us to see the Bot in action, execute an approval command and deploy the app changes to our Staging environment.
 
 It is always best to properly setup Jenkins with the correct Github accounts and Organization as this will give you the exact experience as a developer when interacting with Jenkins X via Github PRs.
 

--- a/content/en/docs/managing-jx/tutorials/progressive-delivery.md
+++ b/content/en/docs/managing-jx/tutorials/progressive-delivery.md
@@ -6,13 +6,13 @@ weight: 30
 ---
 
 
-It's likely you have heard of "blue green deployment" or "canary deployment". The idea is to carefully roll out new versions of your application, if problems happen (gasp!) in production, then the system will automatically roll them back, and the majority of users will not be impacted. 
+It's likely you have heard of "blue green deployment" or "canary deployment". The idea is to carefully roll out new versions of your application, if problems happen (gasp!) in production, then the system will automatically roll them back, and the majority of users will not be impacted.
 
-This has become a popular CD technique over the years. 
+This has become a popular CD technique over the years.
 
 As Jenkins X runs on top of Kubernetes, there are some additional built in protections about starting new versions: if a new application fails to start, it is likely that it will never really make it to production, this is a good thing! And you get it for free!
 
-Progressive Delivery takes this a bit further: changes can be rolled out to a small percentage of users or traffic (say 1%) and then progressively released to more users (say 5%) before the delivery is considered complete. 
+Progressive Delivery takes this a bit further: changes can be rolled out to a small percentage of users or traffic (say 1%) and then progressively released to more users (say 5%) before the delivery is considered complete.
 
 > **Progressive Delivery** makes it easier to adopt Continuous Delivery, by deploying new versions to a subset of users and evaluating their correctness and performance before rolling them to the totality of the users, and rolled back if not matching some key metrics.
 
@@ -34,7 +34,7 @@ As the first step three Jenkins X addons need to be installed:
 
 The addons can be installed with
 
-```shell
+```sh
 jx create addon istio --version 1.1.7
 jx create addon flagger
 ```
@@ -43,7 +43,7 @@ This will enable Istio in the **jx-production** namespace for metrics gathering.
 
 Now get the ip of the Istio ingress and point a wildcard domain to it (e.g. `*.example.com`), so we can use it to route multiple services based on host names. The Istio ingress provides the routing capabilities needed for Canary releases (traffic shifting) that the traditional Kubernetes ingress objects do not support.
 
-```shell
+```sh
 kubectl -n istio-system get service istio-ingressgateway \
 -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
@@ -135,7 +135,7 @@ If the metrics we have configured (request duration over 500 milliseconds or mor
 
 To get the Canary events run
 
-```shell
+```sh
 $ kubectl -n jx-production get events --watch \
   --field-selector involvedObject.kind=Canary
 LAST SEEN   FIRST SEEN   COUNT   NAME                                                  KIND     SUBOBJECT   TYPE     REASON   SOURCE    MESSAGE
@@ -154,7 +154,7 @@ LAST SEEN   FIRST SEEN   COUNT   NAME                                           
 
 Flagger includes a Grafana dashboard for visualization purposes as it is not needed for the Canary releases. It can be accessed locally using Kubernetes port forwarding
 
-```shell
+```sh
 kubectl --namespace istio-system port-forward deploy/flagger-grafana 3000
 ```
 

--- a/content/en/docs/managing-jx/tutorials/serverless-apps.md
+++ b/content/en/docs/managing-jx/tutorials/serverless-apps.md
@@ -5,26 +5,26 @@ description: Develop serverless applications with Knative
 weight: 40
 ---
 
-Serverless appications are regular applications that "scale to zero". This means when your application isn't in use - no resources at all will be used. You only pay for what you use. These applications scale up elastically to meet the workload. 
+Serverless appications are regular applications that "scale to zero". This means when your application isn't in use - no resources at all will be used. You only pay for what you use. These applications scale up elastically to meet the workload.
 
-Once you have this feature enabled - all new apps you import or quickstarts you use by default will be serverless style (you can override as needed - see below). You don't have to change the way you build web apps. This is currently in a preview state (but works well), and in future most web apps will work in this fashion (and this will be the default). 
+Once you have this feature enabled - all new apps you import or quickstarts you use by default will be serverless style (you can override as needed - see below). You don't have to change the way you build web apps. This is currently in a preview state (but works well), and in future most web apps will work in this fashion (and this will be the default).
 
 ## Enabling serverless apps
 
-```
+```sh
 jx create addon gloo
 ```
 
-And you are then good to go. Any new projects you create will be created in this serverless style. 
+And you are then good to go. Any new projects you create will be created in this serverless style.
 
 
-## Converting existing applications 
+## Converting existing applications
 
 If you already have a microservice and you want to convert it over to Knative Serve just [import the source repository into Jenkins X](/docs/using-jx/common-tasks/import/) and you should be all done.
 
 If your application was imported recently into Jenkins X but before you installed and enabled Knative Serve you can use [jx edit deploy](/commands/jx_edit_deploy) to switch between the `default` deployment kind (using kubernetes `Deployment` and `Service` resources) and the `knative` kind (using Knative `Service` resource)
 
-```
+```sh
 jx edit deploy
 ```
 
@@ -35,14 +35,14 @@ This command will modify the `knativeDeploy` flag in your helm `charts/myapp/val
 
 You can edit the default deployment kind for your team which is used when’re you create a QuickStart or import a repository via the [jx edit deploy](/commands/jx_edit_deploy) command with the `-t` argument:
 
-```
+```sh
 jx edit deploy -t
 ```
 
 
-### How it works 
+### How it works
 
-We use an open source project called [Knative](https://www.knative.dev/) to provide the elastic scaling of your applications and functions.  
+We use an open source project called [Knative](https://www.knative.dev/) to provide the elastic scaling of your applications and functions.
 
 [Knative Serve](https://www.knative.dev/) exposes functions in any programming language over HTTP with elastic scaling from zero to many pods. This lets you build serverless applications which run on any cloud or kubernetes cluster and make an efficient use of resources.
 
@@ -58,12 +58,12 @@ The Jenkins X builld packs create a Knative Serve resource in your helm chart at
 
 We have a simple command [jx create addon gloo](/commands/jx_create_addon_gloo/) to install Gloo and Knative Serve on Jenkins X:
 
-```
+```sh
 jx create addon gloo
 ```
 This command will install Knative Serve into the `knative-serving` namespace and Gloo into the `gloo-system` namespace. You can check it’s all installed and working via:
 
-```
+```sh
 kubectl get pod -n knative-serving
 kubectl get pod -n gloo-system
 ```
@@ -76,8 +76,8 @@ Now you have installed [Knative Serve](https://www.knative.dev/) snd [Gloo](http
 
 You can check if Knative Serve is being used on your application by doing:
 
-```
-kubectl get ksvc -n jx-staging 
+```sh
+kubectl get ksvc -n jx-staging
 ```
 Which should show all of the Knative Service resources in your Staging environment.
 

--- a/content/en/docs/overview/changelog.md
+++ b/content/en/docs/overview/changelog.md
@@ -18,12 +18,12 @@ type: docs
 
 
 | Clouds with Kaniko Support |
-| --- | 
+| --- |
 | GKE |
 | EKS |
 
 | Clouds supporting bucket log storage |
-| --- | 
+| --- |
 | GKE |
 | EKS |
 
@@ -35,20 +35,20 @@ This section describes any specific manual work arounds you may require above an
 
 ## 25th June 2019: missing image: bitnami/monocular-api
 
-It looks like the monocular docker images got removed today! 
+It looks like the monocular docker images got removed today!
 
 It turns out that monocular is not an absolute requirement for Jenkins X; it works great without it.
 
 So a quick workaround to the problem is to scale down your monocular deployment
 
-``` 
+```sh
 kubectl scale deploy jenkins-x-monocular-api --replicas=0
 kubectl scale deploy jenkins-x-monocular-prerender --replicas=0
 kubectl scale deploy jenkins-x-monocular-ui --replicas=0
-``` 
+```
 
 The latest [version stream release](/docs/concepts/version-stream/) has removed monocular so if you [upgrade your platform
-](/docs/managing-jx/common-tasks/upgrade-jx/) this issue should be resolved. 
+](/docs/managing-jx/common-tasks/upgrade-jx/) this issue should be resolved.
 
 We can always add monocular back as an optional [App](/apps) later on when it works again.
 
@@ -61,7 +61,7 @@ So we highly recommend anyone who has created a Jenkins X installation using Kna
 
 Now the `jx` binary will warn that any attempt at using `--knative-build` when installing is deprecated.
 
-We will soon have a build pack for [Jenkinsfile runner](https://github.com/jenkinsci/jenkinsfile-runner) when using Tekton in case you need to reuse a Jenkinsfile within [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) and Tekton along with support for orchestrating `Jenkinsfile` within a [custom Jenkins server](/docs/managing-jx/common-tasks/custom-jenkins/) 
+We will soon have a build pack for [Jenkinsfile runner](https://github.com/jenkinsci/jenkinsfile-runner) when using Tekton in case you need to reuse a Jenkinsfile within [Serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) and Tekton along with support for orchestrating `Jenkinsfile` within a [custom Jenkins server](/docs/managing-jx/common-tasks/custom-jenkins/)
 
 ## 21st May 2019: Skaffold upgrade to v0.29.0
 
@@ -71,8 +71,8 @@ If you are running a static master or serverless (Jenkins file runner) cluster a
 
 In the `dev` profile, remove the following section:
 
-```
-    artifacts:	
+```yaml
+    artifacts:
     - docker: {}
 ```
 
@@ -83,7 +83,7 @@ For more information, refer to this [PR](https://github.com/jenkins-x-buildpacks
 We are pleased to announce 2.0.x of Jenkins X.
 
 We have changed some of the default CLI arguments when installing Jenkins X.
- 
+
 * we are now deprecating the use of Knative build with Prow / Serverless Jenkins in favor of [Jenkins X Pipelines and Tekton](/docs/concepts/jenkins-x-pipelines/)
 * we default to using `--no-tiller`  to [disable the use of helm's tiller](/news/helm-without-tiller/). We recommend to avoid tiller. If you really still want to use it then use `--no-tiller false` on the CLI when installing Jenkins X.
 
@@ -92,9 +92,9 @@ We have changed some of the default CLI arguments when installing Jenkins X.
 
 We have spotted a regression in the install process that generates an invalid config file inside the secret `jx-install-config` secret.  Whilst the original defect has been fixed, the invalid secret will create an issue with `jx upgrade platform` causing the cluster to loose all secrets.
 
-To work around this, we have added some logic into `jx upgrade platform` to detect the invalid secret and attempt to fix.  This feature is included in jx version `1.3.842`.  An extract of a running upgrade is shown below:  
+To work around this, we have added some logic into `jx upgrade platform` to detect the invalid secret and attempt to fix.  This feature is included in jx version `1.3.842`.  An extract of a running upgrade is shown below:
 
-```
+```sh
 Creating /Users/garethjevans/.jx/adminSecrets.yaml from jx-install-config
 Creating /Users/garethjevans/.jx/extraValues.yaml from jx-install-config
 We have detected that the /Users/garethjevans/.jx/adminSecrets.yaml file has an invalid format
@@ -107,15 +107,15 @@ Anonymous access to Nexus has been disabled by default, this has implications to
 
 This can be done automatically using:
 
-```
+```sh
 jx upgrade platform --update-secrets
 ```
 
 NOTE: this will regenerate the settings.xml from a defined template.
 
-If you would prefer to apply this changes manually, edit the secret `jenkins-maven-settings`, duplicating the server block for `local-nexus`, changing the server id to `nexus` e.g. 
+If you would prefer to apply this changes manually, edit the secret `jenkins-maven-settings`, duplicating the server block for `local-nexus`, changing the server id to `nexus` e.g.
 
-```
+```xml
 <server>
     <id>local-nexus</id>
     <username>admin</username>
@@ -135,21 +135,21 @@ https://github.com/jenkins-x/jx/issues/2539
 https://github.com/jenkins-x/jx/issues/2561
 https://github.com/jenkins-x/jx/issues/2544
 
-The fixes involve upgrading to a newer version of Prow and Knative Build, the latter caused an issue when performing a traditional `jx upgrade addon` so we recommend uninstalling Knative Build first (removes Knative Build related Custom Resource Definitions) and install the latest release.  
+The fixes involve upgrading to a newer version of Prow and Knative Build, the latter caused an issue when performing a traditional `jx upgrade addon` so we recommend uninstalling Knative Build first (removes Knative Build related Custom Resource Definitions) and install the latest release.
 
-```
+```sh
 jx delete addon knative-build
 ```
 
 And to be extra sure it’s gone maybe do an extra:
 
-```
+```sh
 helm del --purge knative-build
 ```
 
 then:
 
-```
+```sh
 jx upgrade cli
 jx upgrade addon prow
 ```

--- a/content/en/docs/reference/commands/jx_add_app.md
+++ b/content/en/docs/reference/commands/jx_add_app.md
@@ -12,23 +12,23 @@ Adds an app
 
 Adds an app to Jenkins X.
 
-```
+```sh
 jx add app [flags]
 ```
 
 ### Examples
 
-```
+```sh
   # Add an app
   jx add app jx-app-jacoco
-  
+
   # Add an app from a local path
   jx add app .
 ```
 
 ### Options
 
-```
+```sh
       --alias string         An alias to use for the app if you wish to install multiple instances of the same app
       --auto-merge           Automatically merge GitOps pull requests that pass CI
       --helm-update          Should we run helm update first to ensure we use the latest version (available when NOT using GitOps for your dev environment) (default true)
@@ -44,7 +44,7 @@ jx add app [flags]
 
 ### Options inherited from parent commands
 
-```
+```sh
   -b, --batch-mode   Runs in batch mode without prompting for user input (default true)
       --verbose      Enables verbose output
 ```

--- a/content/en/docs/reference/components/build-packs.md
+++ b/content/en/docs/reference/components/build-packs.md
@@ -15,7 +15,7 @@ The build packs are used to default the following files if they do not already e
 * `Dockerfile` to turn the code into an immutable docker image for running on kubernetes
 * `Jenkinsfile` to define the declarative Jenkins pipeline to define the CI/CD steps for the application
 * helm chart in the `charts` folder to generate the kubernetes resources to run the application on kubernetes
-* a _preview chart_ in the `charts/preview` folder to define any dependencies for deploying a [preview environment](/docs/concepts/features/#preview-environments) on a Pull Request   
+* a _preview chart_ in the `charts/preview` folder to define any dependencies for deploying a [preview environment](/docs/concepts/features/#preview-environments) on a Pull Request
 
 The default build packs are at [https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes) with a folder for each language or build tool.
 
@@ -30,17 +30,17 @@ For example the [jenkins-x-kubernetes](https://github.com/jenkins-x-buildpacks/j
 To do this we've introduced a simple new YAML file format for defining pipelines.
 
 
-## Pipelines 
+## Pipelines
 
 Each Pipeline YAML file has a number of separate logical pipelines:
 
 * `release` for processing merges to the `master` branch which typically creates a new version and release then triggers promotion
 * `pullRequest` for processing Pull Requests
-* `feature` for processing merges to a feature branch. Though note that the [accelerate book](/about/accelerate/) recommends against long term feature branches. Instead consider using trunk based development which is a practice of high performing teams. 
+* `feature` for processing merges to a feature branch. Though note that the [accelerate book](/about/accelerate/) recommends against long term feature branches. Instead consider using trunk based development which is a practice of high performing teams.
 
 ## Life Cycles
 
-Then each pipeline has a number of distinct life cycle phases - rather like maven has `clean`, `compile`, `compile-test`, `package` etc. 
+Then each pipeline has a number of distinct life cycle phases - rather like maven has `clean`, `compile`, `compile-test`, `package` etc.
 
 The life cycle phases in Jenkins X Pipeline YAML are:
 
@@ -61,7 +61,7 @@ A Pipeline YAML can extend another YAML file. You can reference a base pipeline 
 
 Rather like classes in languages like Java you can override steps in a Pipeline YAML from a base Pipeline YAML. This lets you reuse the steps in a base pipeline's life cycle then add your own additional steps.
 
-By default any steps you define are added after the base pipeline YAML steps like in [this example](https://github.com/jenkins-x/jx/blob/0520fe3d9740cbcb1cc9754e173fe7726219f58e/pkg/jx/cmd/test_data/step_buildpack_apply/inheritence/pipeline.yaml#L7). 
+By default any steps you define are added after the base pipeline YAML steps like in [this example](https://github.com/jenkins-x/jx/blob/0520fe3d9740cbcb1cc9754e173fe7726219f58e/pkg/jx/cmd/test_data/step_buildpack_apply/inheritence/pipeline.yaml#L7).
 
 You can add steps before the base pipeline steps using the `preSteps: ` property like [this example](https://github.com/jenkins-x/jx/blob/0520fe3d9740cbcb1cc9754e173fe7726219f58e/pkg/jx/cmd/test_data/step_buildpack_apply/inheritence2/pipeline.yaml#L6)
 
@@ -108,29 +108,29 @@ pipeline {
           container('foo') {
             sh "foo deploy"
           }
-```          
+```
 
 Once your `Jenkinsfile` is capable of doing CI/CD for your language/runtime on your sample project then we should be able to take the `Dockerfile`, `Jenkinsfile` and charts folder and copy them into a folder in your fork of the [jenkins-x/draft-packs repository](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes).
 
 You can try that out locally by adding these files to your local clone of the build packs repository at ` ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs`
 
-e.g. 
+e.g.
 
-```shell 
+```sh
 export PACK="foo"
 mkdir ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/$PACK
 cp Dockerfile Jenkinsfile  ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/$PACK
 
 # the charts will be in some folder charts/somefoo
 cp -r charts/somefoo ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/$PACK/charts
-```   
+```
 
 Once your build pack is in a folder at `~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/`
 then it should be usable by the [jx import](/commands/jx_import) code
 which uses programming language detection to find the most suitable build pack to use when importing a project.
 If your build pack requires custom logic to detect it then let us know
 and we can help patch [jx import](/commands/jx_import) to work better for your build pack.
-For example, we have some custom logic for handling [Maven and Gradle better](https://github.com/jenkins-x/jx/blob/712d9edf5e55aafaadfb3e0ac57692bb44634b1c/pkg/jx/cmd/common_buildpacks.go#L82:L108).     
-   
-          
-If you need any more help [join the community](/community/)  
+For example, we have some custom logic for handling [Maven and Gradle better](https://github.com/jenkins-x/jx/blob/712d9edf5e55aafaadfb3e0ac57692bb44634b1c/pkg/jx/cmd/common_buildpacks.go#L82:L108).
+
+
+If you need any more help [join the community](/community/)

--- a/content/en/docs/reference/components/cloud-native-jenkins.md
+++ b/content/en/docs/reference/components/cloud-native-jenkins.md
@@ -11,32 +11,32 @@ Jenkins X helps to support _cloud native Jenkins_ via:
 
 * orchestrating either [serverless Jenkins](/news/serverless-jenkins/) using [prow](/architecture/prow) or a Static Jenkins masters per team. This lets teams move towards serverless while bring along static masters too.
 * each team can install its own Jenkins X in its own namespace (via `jx install --namespace myteam`)
-* support for different workloads per team (see [jx edit buildpack](/commands/jx_edit_buildpack/)). 
+* support for different workloads per team (see [jx edit buildpack](/commands/jx_edit_buildpack/)).
 
 
 ## Different workloads
 
-Some teams develop cloud native applications on kubernetes and so should use the `kubernetes workloads` option. 
+Some teams develop cloud native applications on kubernetes and so should use the `kubernetes workloads` option.
 
 For teams that do not deploy applications to kubernetes - such as delivering libraries or binaries - there's a new `library workloads` option which has CI and automated releases but no CD.
 
 When you [create a cluster](getting-started/create-cluster/) or [install Jenkins X](/docs/managing-jx/common-tasks/install-on-cluster/) you are prompted to pick between the available build packs.
-  
-```shell 
+
+```sh
 ? Pick workload build pack:   [Use arrows to move, type to filter]
 > Kubernetes Workloads: Automated CI+CD with GitOps Promotion
   Library Workloads: CI+Release but no CD
-```  
+```
 
 You can change this configuration at any time via [jx edit buildpack](/commands/jx_edit_buildpack/).
 
 By default just hit enter to stick to the `kubernetes workloads` option. Though if you have a significant number of libraries you wish to manage you could setup a separate team for this and import your various library projects there.
 
 
-## Current workloads 
+## Current workloads
 
-We store our build packs in [jenkins-x-buildpacks](https://github.com/jenkins-x-buildpacks/) organization at GitHub. Currently we support: 
- 
+We store our build packs in [jenkins-x-buildpacks](https://github.com/jenkins-x-buildpacks/) organization at GitHub. Currently we support:
+
 * the [jenkins-x-classic](https://github.com/jenkins-x-buildpacks/jenkins-x-classic) build pack supports CI+Releases but does not include CD. e.g. do CI and release of your Java libraries or Node modules but don't deploy to Kubernetes
 * the [jenkins-x-kubernetes](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes) build pack supports automated CI+CD with GitOps promotion and Preview Environments for `kubernetes workloads`
 

--- a/content/en/docs/reference/components/custom-jenkins.md
+++ b/content/en/docs/reference/components/custom-jenkins.md
@@ -15,7 +15,7 @@ Jenkins X now has a [Jenkins App](https://github.com/jenkins-x-apps/jx-app-jenki
 
 ## Why Custom Jenkins?
 
-This app lets you maintain your investment in your existing Jenkins pipelines, invoking them in a custom Jenkins Server of your own choosing and configuration while you start to use more of the automated CI/CD in Jenkins X for new libraries and microservices using either [serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) or the embedded static Jenkins server in Jenkins X. 
+This app lets you maintain your investment in your existing Jenkins pipelines, invoking them in a custom Jenkins Server of your own choosing and configuration while you start to use more of the automated CI/CD in Jenkins X for new libraries and microservices using either [serverless Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) or the embedded static Jenkins server in Jenkins X.
 
 You can then mix and match between the automated CI/CD in Jenkins X and your custom Jenkins pipelines - all orchestrated nicely together with Jenkins X!
 
@@ -23,15 +23,15 @@ You can then mix and match between the automated CI/CD in Jenkins X and your cus
 
 To install the custom Jenkins server you need to run the following command:
 
-```shell 
+```sh
 jx add app jenkins
 ```
 
 This will install a new Jenkins Server in your current Team. It should then show up via...
 
-```shell
+```sh
 jx open
-```    
+```
 
 This will also create an API token automatically so that the `jx` CLI can query or start pipelines in the custom Jenkins server. It can take a minute or so for the setup job to complete.
 
@@ -39,12 +39,12 @@ This will also create an API token automatically so that the `jx` CLI can query 
 
 Unfortunately there is a limitation on the current Jenkins app that it does not prompt you with the password as you add the Jenkins App.
 
-So to find the password you will need to find it by hand I'm afraid. 
+So to find the password you will need to find it by hand I'm afraid.
 
 * download [ksd](https://github.com/mfuentesg/ksd) and add it to your $PATH
 * type the following (you may need to change the `Secret` name if you use a different alias for your Jenkins server):
 
-```shell
+```sh
 kubectl get secret jx-jx-app-jenkins -o yaml | ksd
 ```
 
@@ -57,8 +57,8 @@ The `jx` command which work with Jenkins servers can all work directly with your
 
 If you only have one custom Jenkins App in your Team you can use `-m` to specify you want to work with a custom Jenkins server. Otherwise you can specify `-n myjenkinsname`.
 
-```shell
-# view the pipelines 
+```sh
+# view the pipelines
 jx get pipeline -m
 
 # view the log of a pipeline
@@ -71,8 +71,8 @@ jx console -m
 jx start pipeline -m
 ```
 
-## Managing custom Jenkins Servers via GitOps 
+## Managing custom Jenkins Servers via GitOps
 
 We have designed the Jenkins App for Jenkins X using the [App extension framework](/docs/contributing/addons/) which means you can manage your custom Jenkins servers via [GitOps](/docs/managing-jx/common-tasks/manage-via-gitops/) - keeping all of the apps, their version and configuration in git and using the Jenkins X tooling to add/update/configure/delete apps.
 
- 
+

--- a/content/en/docs/reference/components/custom-resources.md
+++ b/content/en/docs/reference/components/custom-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Resources
 linktitle: Custom Resources
-description: Custom Resources defined by Jenkins X 
+description: Custom Resources defined by Jenkins X
 parent: "components"
 weight: 10
 aliases:
@@ -13,27 +13,27 @@ Kubernetes provides an extension mechanism called [Custom Resources](https://kub
 So in Jenkins X, we have added a number of Custom Resources to help extend Kubernetes to support CI/CD.
 
 You can also [browse the Custom Resource API Reference](/apidocs/)
-                
+
 ## Environments
 
 Jenkins X natively supports [environments](/docs/concepts/features/#environments) allowing them to be defined for your team and then queried via [jx get environments](/commands/jx_get_environments):
 
-```shell
+```sh
 jx get environments
 ```
 
-Under the covers that command uses the custom Kubernetes resource `Environments`. 
+Under the covers that command uses the custom Kubernetes resource `Environments`.
 
 So you can also query the environments via [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) as well:
 
-  
-```shell
+
+```sh
 kubectl get environments
 ```
 
 Or edit them via `YAML` directly if you want:
 
-```shell
+```sh
 kubectl edit env staging
 ```
 
@@ -67,7 +67,7 @@ Or when you perform `jx import` or `jx create quickstart` you can pass in a `--s
 This resource stores the pipeline status in terms of Jenkins Pipeline stages plus the [promotion activity](/docs/concepts/features/#promotion).
 
 This resource is also used by the [jx get activities](/commands/jx_get_activities) command.
-  
+
 ## Team
 
 The `Team` Custom Resource is created via the [jx create team](/commands/jx_create_team/) command and is used by the `team controller` to watch for new `Team` resources and then create an installation of Jenkins X in the `teams` namespace. For more background on teams see the [team feature](/docs/concepts/features/#teams).
@@ -84,4 +84,4 @@ The `EnvironmentRoleBinding` resource is like the standard Kubernetes [RoleBindi
 
 This makes it easy to bind a `Role` to either all environments, all preview environments or both or a given set of users.
 
- 
+

--- a/content/en/docs/reference/components/docker-registry.md
+++ b/content/en/docs/reference/components/docker-registry.md
@@ -1,7 +1,7 @@
 ---
 title: Docker Registry
 linktitle: Docker Registry
-description: Configuring your docker registry 
+description: Configuring your docker registry
 weight: 90
 aliases:
   - /docs/managing-jx/common-tasks/docker-registry
@@ -18,15 +18,15 @@ If you are using the public cloud you may wish to take advantage of your cloud p
 ### If you are using Static Jenkins Master
 To specify the Docker Registry host/port you can use the Jenkins Console:
 
-```
+```sh
 jx console
-``` 
+```
 
 Then navigate to `Manage Jenkins -> Configure System` and change the `DOCKER_REGISTRY` environment variable to point to your docker registry of choice.
 
 Another approach is to add the following to your `values.yaml` file for your customization of the Jenkins X platform helm charts:
 
-```yaml 
+```yaml
 jenkins:
   Servers:
     Global:
@@ -36,7 +36,7 @@ jenkins:
 
 ## Update the config.json secret
 
-Next you will need to update the `config.json` secret for docker. 
+Next you will need to update the `config.json` secret for docker.
 
 You can do this via the [jx create docker auth](/commands/jx_create_docker/) command line tool:
 
@@ -73,7 +73,7 @@ Then to update the `jenkins-docker-cfg` secret you can do the following:
 ```
 kubectl delete secret jenkins-docker-cfg
 kubectl create secret generic jenkins-docker-cfg --from-file=./config.json
-```   
+```
 
 **NOTE** that the file must be called `config.json` as the file name is used in the key of the underlying `Secret` in kubernetes
 
@@ -81,7 +81,7 @@ kubectl create secret generic jenkins-docker-cfg --from-file=./config.json
 
 If you want to publish images to docker hub then you need to modify your `config.json` as described above to something like:
 
-```json 
+```json
 {
     "auths": {
         "https://index.docker.io/v1/": {
@@ -90,14 +90,14 @@ If you want to publish images to docker hub then you need to modify your `config
         }
     }
 }
-``` 
+```
 
 ## Using jFrog BinTray (Artifactory)
 Using the jFrog BinTray as a private registry is possible.  This has only been tested when creating a new cluster and passing the `--docker-registry=private-reg.bintray.io`.  After creating your cluster, you will want to do the following:
 
-1. Delete the existing `Secret` called `jenkins-docker-cfg` by executing 
+1. Delete the existing `Secret` called `jenkins-docker-cfg` by executing
 
-```bash
+```sh
 kubectl delete secret jenkins-docker-cfg
 ```
 2. Create a local file called `config.json` and its value should be in this format (update values based on your registry user account and FQDN).
@@ -114,8 +114,8 @@ kubectl delete secret jenkins-docker-cfg
 ```
 2. Create the new `jenkins-docker-cfg` `Secret` with the contents of the `config.json` as follows:
 
-```bash
- kubectl create secret generic jenkins-docker-cfg --from-file=./config.json
+```sh
+kubectl create secret generic jenkins-docker-cfg --from-file=./config.json
 ```
 
 That should do it, you should now be able to run pipelines and store images in the jFrog BinTray Registry.

--- a/content/en/docs/reference/components/git.md
+++ b/content/en/docs/reference/components/git.md
@@ -9,7 +9,7 @@ aliases:
 
 
 Jenkins X defaults to using [GitHub](https://github.com/), the free public git hosting solution for open source projects.
- 
+
 However when working in the enterprise you may wish to use different git servers.
 
 
@@ -41,14 +41,14 @@ If you wish to use a different git provider for your environments then when you 
 
 
 e.g. to [create a new cluster](/docs/getting-started/setup/create-cluster/)
- 
-``` 
+
+```sh
 jx create cluster gke --no-default-environments
 ```
 
 or to [install in an existing cluster](/docs/managing-jx/common-tasks/install-on-cluster/)
 
-``` 
+```sh
 jx install --no-default-environments
 ```
 
@@ -57,14 +57,14 @@ Then once Jenkins X is installed you can then [add a new git provider](#adding-a
 
 Then when the git provider is setup you can verify it is available and has the right `gitKind` via:
 
-``` 
+```sh
 jx get git server
 ```
 
 
 Now create the `Staging` and `Production` environments using whatever git provider you wish via:
 
-``` 
+```sh
 jx create env staging --git-provider-url=https://gitproviderhostname.com
 jx create env production --git-provider-url=https://gitproviderhostname.com
 ```
@@ -73,8 +73,8 @@ jx create env production --git-provider-url=https://gitproviderhostname.com
 ## Adding a new git provider
 
 If you already have a git server somewhere you can add it into Jenkins X via [jx create git server](/commands/jx_create_git_server):
-                                    
-``` 
+
+```sh
 jx create git server gitKind someURL
 ```
 
@@ -82,20 +82,19 @@ Where the `gitKind` is one of the supported git provider kinds like `github, git
 
 You can verify what server URLs and `gitKind` values are setup via
 
-``` 
+```sh
 jx get git server
 ```
 
-**NOTE** please make sure you set the right `gitKind` for your git provider otherwise the wrong underlying REST API provider will be invoked! 
+**NOTE** please make sure you set the right `gitKind` for your git provider otherwise the wrong underlying REST API provider will be invoked!
 
 ## GitHub Enterprise
 
 To add a GitHub Enterprise server try:
 
-``` 
+```sh
 jx create git server github https://github.foo.com -n GHE
 jx create git token -n GHE myusername
-
 ```
 
 Where `-n` is the name for the git service.
@@ -104,14 +103,14 @@ Where `-n` is the name for the git service.
 
 To add BitBucket Cloud try:
 
-```
+```sh
 jx create git server bitbucketcloud -n BitBucket https://bitbucket.org
 jx create git token -n BitBucket myusername
 ```
 
 Please make sure that the `gitKind` is properly set to `bitbucketcloud` via the following command
 
-``` 
+```sh
 jx get git server
 ```
 
@@ -121,7 +120,7 @@ and look in the `Kind` column.
 
 To add BitBucket Standalone Server try:
 
-```
+```sh
 jx create git server bitbucketserver -n BitBucket https://your_server_address
 jx create git token -n BitBucket myusername
 ```
@@ -130,39 +129,38 @@ jx create git token -n BitBucket myusername
 
 To add a git server for Gitlab and a token try:
 
-```
+```sh
 jx create git server gitlab https://gitlab.com/ -n gitlab
 jx create git token -n gitlab myusername
 ```
-   
-   
+
 ### Adding user tokens
 
 To use a git server you need to add a user name and API token via [jx create git token](/commands/jx_create_git_token):
 
-``` 
+```sh
 jx create git token -n myProviderName myUserName
 ```
 
-You will then be prompted for the API token 
+You will then be prompted for the API token
 
 ### Kubernetes hosted git providers
 
-You can install git providers inside the kubernetes cluster running Jenkins X. 
+You can install git providers inside the kubernetes cluster running Jenkins X.
 
 e.g. there is an addon for [gitea](https://gitea.io/en-us/) that lets you install gitea as part of your Jenkins X installation.
 
 To use [gitea](https://gitea.io/en-us/) with Jenkins X then you need to enable the `gitea` addon before installing Jenkins X:
 
-``` 
+```sh
 jx edit addon gitea -e true
-``` 
+```
 
 You can view the enabled addons via [jx get addons](/commands/jx_get_addons):
 
-``` 
+```sh
 jx get addons
-``` 
+```
 
 Now when you [install Jenkins X](/docs/getting-started/) it will also install the `gitea` addon.
 
@@ -173,5 +171,5 @@ Then whenever Jenkins X needs to create a git repository for an Environment or f
 
 At the time of writing the [gitea plugin for Jenkins](https://issues.jenkins-ci.org/browse/JENKINS-50459) does not correctly update Pull Request and git commit build statuses which breaks the GitOps promotion pipelines. Promotion can work through manual approval, but the pipeline reports a failure.
 
-Another issue is new projects created by `jx` inside `gitea` do not get the [merge buttons enabled on Pull Requests](https://github.com/go-gitea/go-sdk/issues/100). The work around is after a project is created on github you go to the `Settings` page for the repository inside the `gitea` web console and enable the merge buttons there. 
+Another issue is new projects created by `jx` inside `gitea` do not get the [merge buttons enabled on Pull Requests](https://github.com/go-gitea/go-sdk/issues/100). The work around is after a project is created on github you go to the `Settings` page for the repository inside the `gitea` web console and enable the merge buttons there.
 

--- a/content/en/docs/reference/components/lighthouse.md
+++ b/content/en/docs/reference/components/lighthouse.md
@@ -8,30 +8,30 @@ aliases:
   - /architecture/lighthouse
 ---
 
-[Prow](prow.html) is a great way to do [ChatOps](/docs/using-jx/faq/chatops) with [Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) though unfortunately its only supported for GitHub.com and is quite heavy and complex. To work around this we've created [Lighthouse](https://github.com/jenkins-x/lighthouse). 
- 
+[Prow](prow.html) is a great way to do [ChatOps](/docs/using-jx/faq/chatops) with [Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) though unfortunately its only supported for GitHub.com and is quite heavy and complex. To work around this we've created [Lighthouse](https://github.com/jenkins-x/lighthouse).
+
 [Lighthouse](https://github.com/jenkins-x/lighthouse) is a lightweight [ChatOps](/docs/using-jx/faq/chatops) based webhook handler which can trigger [Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) on webhooks from multiple git providers such as: GitHub, GitHub Enterprise, BitBucket Server, BitBucket Cloud, GitLab, Gogs and Gitea.
 
 Currently Lighthouse is focussed on using [Jenkins X Pipelines](/docs/concepts/jenkins-x-pipelines/) with tekton though longer term it could be reused with tekton orchestrating Jenkins pipelines via the [Custom Jenkins Server App](/docs/managing-jx/common-tasks/custom-jenkins/)
 
-## Features 
+## Features
 
-Currently Lighthouse supports the common [prow plugins](https://github.com/jenkins-x/lighthouse/tree/master/pkg/prow/plugins) and handles push webhooks to branches & Pull Request webhooks to then trigger Jenkins X pipelines. 
-    
-Lighthouse uses the same `config.yaml` and `plugins.yaml` file structure from Prow so that we can easily migrate from `prow <-> lighthouse`. 
+Currently Lighthouse supports the common [prow plugins](https://github.com/jenkins-x/lighthouse/tree/master/pkg/prow/plugins) and handles push webhooks to branches & Pull Request webhooks to then trigger Jenkins X pipelines.
 
-This also means we get to reuse the clean generation of Prow configuration from the `SourceRepository`, `SourceRepositoryGroup` and `Scheduler` CRDs integrated into [jx boot](/docs/reference/boot/). e.g. here's the [default scheduler configuration](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/env/templates/default-scheduler.yaml) which is used for any project imported into your Jenkins X cluster; without you having to touch the actual prow configuration files. You can create many schedulers and associate them to different `SourceRepository` resources.   
+Lighthouse uses the same `config.yaml` and `plugins.yaml` file structure from Prow so that we can easily migrate from `prow <-> lighthouse`.
 
-We can also reuse Prow's capability of defining many separate pipelines on a repository (for PRs or releases) via having separate `contexts`. Then on a Pull Request we can use `/test something` or `/test all` to trigger pipelines and use the `/ok-to-test` and `/approve` or `/lgtm` commands 
+This also means we get to reuse the clean generation of Prow configuration from the `SourceRepository`, `SourceRepositoryGroup` and `Scheduler` CRDs integrated into [jx boot](/docs/reference/boot/). e.g. here's the [default scheduler configuration](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/env/templates/default-scheduler.yaml) which is used for any project imported into your Jenkins X cluster; without you having to touch the actual prow configuration files. You can create many schedulers and associate them to different `SourceRepository` resources.
+
+We can also reuse Prow's capability of defining many separate pipelines on a repository (for PRs or releases) via having separate `contexts`. Then on a Pull Request we can use `/test something` or `/test all` to trigger pipelines and use the `/ok-to-test` and `/approve` or `/lgtm` commands
 
 
 ## Using Lighthouse with boot
 
 We have integrated [lighthouse](https://github.com/jenkins-x/lighthouse) into [jx boot](/docs/reference/boot/). To switch to `lighthouse` from `prow` you need to add something like this to your `jx-requirements.yml` file:
 
-```yaml 
+```yaml
 webhook: lighthouse
-``` 
+```
 
 Once you have modified your `jx-requirements.yml` file you just need to run `jx boot`.
 
@@ -39,7 +39,7 @@ If you are using something else other than github.com as your git provider you w
 
 ## GitHub Enterprise
 
-```yaml 
+```yaml
 cluster:
   provider: gke
   zone: europe-west1-c
@@ -48,11 +48,11 @@ cluster:
   gitName: ghe
   gitServer: https://my-github.com
 webhook: lighthouse
-```     
+```
 
 ## BitBucket Server
 
-```yaml 
+```yaml
 cluster:
   provider: gke
   environmentGitOwner: myowner
@@ -60,11 +60,11 @@ cluster:
   gitName: bs
   gitServer: https://my-bitbucket-server.com
 webhook: lighthouse
-``` 
+```
 
 ## GitLab
 
-```yaml 
+```yaml
 cluster:
   provider: gke
   environmentGitOwner: myowner
@@ -72,7 +72,7 @@ cluster:
   gitName: gitlab
   gitServer: https://my-gitlab-server.com
 webhook: lighthouse
-``` 
+```
 
 ## Comparisons to Prow
 
@@ -80,7 +80,7 @@ Lighthouse is very prow-like and currently reuses the Prow plugin source code an
 
 Its got a few differences though:
 
-* rather than be GitHub specific lighthouse uses [jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) so it can support any git provider 
+* rather than be GitHub specific lighthouse uses [jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) so it can support any git provider
 * lighthouse is mostly like `hook` from Prow; an auto scaling webhook handler - to keep the footprint small. This also means if anything goes wrong handling webhooks you only have one pod to look into.
 * lighthouse is also very light. In Jenkins X we have about 10 pods related to prow; with lighthouse we have just 1 along with the tekton controller itself. That one lighthouse pod could easily be auto scaled too from 0 to many as it starts up very quickly.
 * lighthouse focuses purely on Tekton pipelines so it does not require a `ProwJob` CRD; instead a push webhook to a release or pull request branch can trigger zero to many `PipelineRun` CRDs instead
@@ -89,7 +89,7 @@ Its got a few differences though:
 
 ## Porting Prow commands
 
-If there are any prow commands you want which we've not yet ported over, its relatively easy to port prow plugins. 
+If there are any prow commands you want which we've not yet ported over, its relatively easy to port prow plugins.
 
 We've reused the prow plugin code and configuration code; so its mostly a case of switching imports of `k8s.io/test-infra/prow` to `github.com/jenkins-x/lighthouse/pkg/prow` - then modifying the github client structs from, say, `github.PullRequest` to `scm.PullRequest`.
 

--- a/content/en/docs/reference/components/pod-templates.md
+++ b/content/en/docs/reference/components/pod-templates.md
@@ -1,7 +1,7 @@
 ---
 title: Pod Templates
 linktitle: Pod Templates
-description: Pods used to implement Jenkins pipelines 
+description: Pods used to implement Jenkins pipelines
 weight: 160
 aliases:
   - /docs/managing-jx/common-tasks/pod-templates
@@ -20,7 +20,7 @@ The Kubernetes plugin uses _pod templates_ to define the pod used to run a CI/CD
 
 ## Referring to Pod Templates
 
-Jenkins X comes with a default set of pod templates for supported languages and runtimes in our [build packs](/architecture/build-packs) and are named something like: `jenkins-$PACKNAME`. 
+Jenkins X comes with a default set of pod templates for supported languages and runtimes in our [build packs](/architecture/build-packs) and are named something like: `jenkins-$PACKNAME`.
 
 For example the [maven build pack](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/blob/master/packs/maven/) uses the pod template `jenkins-maven`.
 
@@ -44,49 +44,49 @@ pipeline {
           }
           ...
 ```
- 
+
 ## Submitting new Pod Templates
 
 If you are working on a new [build pack](/architecture/build-packs) then we'd love you to [submit](/docs/contributing/) a new pod template and we can include it in the Jenkins X distribution!
 
 There now follows instructions on how to do this - please if anything is not clear come [join the community and just ask](/community/) we are happy to help!
 
-To submit a new build pack: 
+To submit a new build pack:
 
 * fork the [jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform/) repository
 * add your build pack to the [values.yaml file in the jenkins-x-platform repository](https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml) in the `jenkins.Agent.PodTemplates` section of the YAML
 * you may want to start by copy/pasting the most similar existing pod template (e.g. copy `Maven` if you are working on a Java based build pod) and just configuring the name, label and `Image` etc.
-* now submit a Pull Request on the [jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform/) repository for your pod template 
+* now submit a Pull Request on the [jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform/) repository for your pod template
 
 ### Build containers
 
-When using pod templates and Jenkins pipelines you could use lots of different containers for each tool. e.g. one container for `maven` and another for `git` etc. 
+When using pod templates and Jenkins pipelines you could use lots of different containers for each tool. e.g. one container for `maven` and another for `git` etc.
 
 We've found its much simpler to just have a single builder container with all the common tools inside. This also means you can use `kubectl exec` or [jx rsh](/commands/jx_rsh) to open a shell inside the build pod and have all the tools you need available for use when debugging/diagnosing problem pipelines.
 
 So we have a [builder-base](https://github.com/jenkins-x/builder-base) docker image which [contains all the different tools](https://github.com/jenkins-x/builder-base/blob/master/Dockerfile#L21-L70) we tend to use in CI/CD pipelines like `jx, skaffold, helm, git, updatebot`.
 
-If you want to use a single builder image for your new pod template then you could use builder base as the base and then add your custom tools on top. 
+If you want to use a single builder image for your new pod template then you could use builder base as the base and then add your custom tools on top.
 
 e.g. [builder-maven](https://github.com/jenkins-x/builder-maven) uses a [Dockerfile](https://github.com/jenkins-x/builder-maven/blob/master/Dockerfile#L1) to reference the builder base.
 
-So the simplest thing could be to copy a similar builder - like [builder-maven](https://github.com/jenkins-x/builder-maven) and then edit the `Dockerfile` to add whatever build tools you need. 
+So the simplest thing could be to copy a similar builder - like [builder-maven](https://github.com/jenkins-x/builder-maven) and then edit the `Dockerfile` to add whatever build tools you need.
 
 We love Pull Requests and [contributions](/docs/contributing/) so please submit Pull Requests for new build containers and Pod Templates and we're more than happy to [help](/docs/contributing/)!
 
 ## Adding your own Pod Templates
 
-To keep things DRY and simple we tend to define pod templates in the Jenkins configuration then refer to the by name in the `Jenkinsfile`. 
+To keep things DRY and simple we tend to define pod templates in the Jenkins configuration then refer to the by name in the `Jenkinsfile`.
 
 There are attempts to make it easy to inline pod template definitions inside your `Jenkinsfile` if you need it; though a pod template tends to have lots of developer environment specific stuff inside it, like secrets, so we'd prefer to keep most of the pod templates inside the source code of your development environment rather than copy/pasting them into each app.
 
 Today the easiest way to add new Pod Templates is via the Jenkins console. e.g.
 
-```bash 
+```sh
 jx console
 ```
 
-That will open the Jenkins console. Then navigate to `Manage Jenkins` (on the left hand menu) then `Configure System`. 
+That will open the Jenkins console. Then navigate to `Manage Jenkins` (on the left hand menu) then `Configure System`.
 
 You will now be faced with a large page of configuration options ;) The pod templates are usually towards the bottom; you should see all the current pod templates for things like maven, NodeJS etc.
 

--- a/content/en/docs/reference/components/vault.md
+++ b/content/en/docs/reference/components/vault.md
@@ -107,7 +107,7 @@ safe set /secret/my-cluster-name/creds/my-secret username=myname password=mytoke
 
 If you have a blob of JSON to encode as a secret, such as a service account key then convert the file to base64 first then set it...
 
-```                                                              
+```sh
 cat my-service-account.json | base64 > myfile.txt
 safe set /secret/my-cluster-name/creds/my-secret json=@myfile.txt
 ```

--- a/content/en/docs/reference/devpods.md
+++ b/content/en/docs/reference/devpods.md
@@ -8,18 +8,18 @@ weight: 20
 The initial focus of Jenkins X is around automating and improving CI/CD for kubernetes. The use of [Preview Environments](/docs/concepts/features/#preview-environments) really helps to validate and approve Pull Requests before they get merged to `master`; but how do you try things out before you are ready submit a Pull Request?
 
 Jenkins X has a concept of `Dev Pods` which are pods for developers to use as a terminal/shell which are based on the exact same operating system, docker containers and tools installed as the [pod templates](/docs/managing-jx/common-tasks/pod-templates/) used in the Jenkins X CI/CD pipelines.
- 
+
 This lets build, run tests or redeploy apps before you commit to git safe in the knowledge you're using the exact same tools as the CI/CD pipelines!
 
 ## Creating a DevPod
 
-To create your own `DevPod` use the command [jx create devpod](/commands/jx_create_devpod/). 
+To create your own `DevPod` use the command [jx create devpod](/commands/jx_create_devpod/).
 
 For example if you want to create a `maven` based DevPod use:
 
-```shell 
+```sh
 jx create devpod -l maven
-```     
+```
 
 This will then create a new `DevPod` based on the maven based [pod template](/docs/managing-jx/common-tasks/pod-templates/) and open your terminal inside that pod. You are now free to use the various tools like `git, docker, maven, skaffold, jx` which will all be using the same exact configuration as the CI/CD pipelines will.
 
@@ -29,7 +29,7 @@ This will then create a new `DevPod` based on the maven based [pod template](/do
 If you don't use `--sync` then the DevPod will embed the [web based version of VS Code](https://github.com/cdr/code-server) in your DevPod so that you can open the IDE in a browser and work on the source code inside your DevPod!
 
 The source code is mounted into the workspace of the DevPod in the folder `/workspace`.
- 
+
 To get an incremental redeploy as you edit source inside VS Code then open a `Terminal` in VS Code and type:
 
 `./watch.sh`
@@ -52,7 +52,7 @@ Here's a [demo showing how to use web based VS Code in a DevPod](/images/develop
 If you don't use `--sync` and you use `--theia` then the DevPod will embed the [Theia IDE](https://www.theia-ide.org/) so that you can open the IDE in a browser and work on the source code inside your DevPod!
 
 The source code is mounted into the workspace of the DevPod in the folder `/workspace`.
- 
+
 To get an incremental redeploy as you edit source inside [Theia IDE](https://www.theia-ide.org/) then type:
 
 `./watch.sh`
@@ -61,15 +61,15 @@ inside the shell of the DevPod.
 
 ## Using a desktop IDE
 
-If you wish to use a desktop IDE then you need to sync your source code you can work on it there, using your preferred editor on your desktop. In this case the workflow is: 
+If you wish to use a desktop IDE then you need to sync your source code you can work on it there, using your preferred editor on your desktop. In this case the workflow is:
 
 1. run `jx sync` once on your system
 2. cd into your project dir, and run `jx create devpod --reuse --sync`
 3. Once in the DevPod from step 2: run `./watch.sh`
 
-This will open a shell (and create a DevPod, or re-use an existing one) and ensure the changes are synced up to the DevPod. Step 3: when  you run this then any changes you make locally will be pushed up to the DevPod, built, and then a temporary "edit" version of your application will be published. 
+This will open a shell (and create a DevPod, or re-use an existing one) and ensure the changes are synced up to the DevPod. Step 3: when  you run this then any changes you make locally will be pushed up to the DevPod, built, and then a temporary "edit" version of your application will be published.
 
-When you run `jx get applications` you will see your "edit" application listed. You can open this in a browser, and edit away, and refresh, as if you were developing locally. 
+When you run `jx get applications` you will see your "edit" application listed. You can open this in a browser, and edit away, and refresh, as if you were developing locally.
 
 _if you are using the Visual Studio code extension to do this, you don't need to worry about this, it will be done automatically for you_
 
@@ -79,31 +79,31 @@ _if you are using the Visual Studio code extension to do this, you don't need to
 
 If you have other terminals that want to connect into an existing `DevPod` use [jx rsh -d](/commands/jx_rsh/)
 
-```shell 
+```sh
 jx rsh -d
-```  
+```
 
 If you have more than one `DevPod` active you will be prompted for the list of available `DevPod`s to pick from. Otherwise your shell will open in the `DevPod` directly.
 
-If you use `jx create devpod --reuse` it will lazily create a devpod if one doesn't exist for the project  directory you are in. 
+If you use `jx create devpod --reuse` it will lazily create a devpod if one doesn't exist for the project  directory you are in.
 
 ### Viewing my DevPods
 
 Use the [jx get devpod](/commands/jx_get_devpod/) command:
 
-        
-```shell 
+
+```sh
 jx get devpod
-```   
+```
 
 ### Deleting a DevPod
 
 Use the [jx delete devpod](/commands/jx_delete_devpod/) command:
 
-        
-```shell 
+
+```sh
 jx delete devpod
-```   
+```
 
 Then pick the devpod to delete and confirm. Or pass in the name of the devpod you want to delete as an argument.
 
@@ -117,9 +117,9 @@ Otherwise if you are using a desktop IDE you can synchronise your local source c
 This will allow you to edit source code in your preferred [IDE](/developing/ide) like [VS Code](https://code.visualstudio.com/) or [IDEA](https://www.jetbrains.com/idea/).
 
 
-```shell
+```sh
 jx sync
-```   
+```
 
 You just run this once on your system (if you are using the Visual Studio code extension to do this, you don't need to worry about this, it will be done automatically for you)
 
@@ -137,32 +137,32 @@ One of the benefits of integrating with [skaffold](https://github.com/GoogleCont
 
 So inside of your DevPod you can perform a regular build if your app is Java based. e.g. via maven:
 
-```shell
+```sh
 mvn install
 ```
-    
+
 Then to trigger incremental rebuilding and deploying of the local code in the DevPod you can use:
 
-```shell
+```sh
 ./watch.sh
 ```
-    
+
 This will use the `dev` profile to generate a new docker image using the generated _digest_ then use it in the helm chart to deploy.
 
 When you created your DevPod it was associated with an _Edit Environment_ for your _username_ so that any apps deployed in a DevPod will appear in your _Edit Environment_.
 
 So once the `skaffold dev -p dev` (what `watch.sh` does) command has built the docker image and installed the helm chart, your app will show up via  [jx get applications](/commands/applications):
-                                                                                                 
-```shell
+
+```sh
 jx get applications
 ```
 
-Now if you edit code and trigger a docker rebuild, which for most languages is just changing the source code; though for Java apps its whenever you rebuild the jar - the image is regenerated and the helm chart updated!        
+Now if you edit code and trigger a docker rebuild, which for most languages is just changing the source code; though for Java apps its whenever you rebuild the jar - the image is regenerated and the helm chart updated!
 
 ## Using an IDE
 
 One of the easiest ways to get started with DevPods is via an IDE such as [VS Code](https://code.visualstudio.com/). Check out the [Jenkins X plugins for IDEs](/docs/using-jx/common-tasks/ide/)
 
-VS Code has support which automates all the above so you can run a shell/sync quite easily. 
+VS Code has support which automates all the above so you can run a shell/sync quite easily.
 
 

--- a/content/en/docs/reference/multi-cluster.md
+++ b/content/en/docs/reference/multi-cluster.md
@@ -28,15 +28,15 @@ Our assumption with the Environment Controller is that we need something that:
 
 If you are creating a new installation then when you use [jx create cluster](/commands/jx_create_cluster) or [jx install](/commands/jx_install) then please specify `--remote-environments` to indicate that `Staging/Production` environments will be remote from the development cluster.
 
-e.g. 
+e.g.
 
-``` 
+```sh
 jx create cluster gke --remote-environments --tekton
 ```
 
 When creating your Environments via [jx create environment](/commands/jx_create_environment) you can also specify the environment is remote via the `--remote` or answering `Y` to the question when prompted.
 
-What this means is that if an environment is remote to the development cluster then we don't register the release pipeline 
+What this means is that if an environment is remote to the development cluster then we don't register the release pipeline
 of the environment in the Dev cluster; we leave that to the Environment Controller to perform running inside the remote cluster.
 
 
@@ -46,12 +46,12 @@ If you already have a Dev cluster that was setup with `Staging` and `Production`
 
 Edit the environments to mark them as remote via [jx edit environment](/commands/jx_edit_environment):
 
-``` 
-jx edit env staging --remote 
-jx edit env production --remote 
+```sh
+jx edit env staging --remote
+jx edit env production --remote
 ```
 
-You need to manually disable the release pipeline in the Dev cluster. 
+You need to manually disable the release pipeline in the Dev cluster.
 
 e.g. by removing the `postsubmit` setting in your Prow configuration if you are using [serverless Jenkins X Pipelines and tekton](/docs/concepts/jenkins-x-pipelines/) - or comment out the `jx step helm apply` command in your `Jenkinsfile` if using static jenkins server
 
@@ -62,17 +62,17 @@ First you need to connect to your remote kubernetes cluster for `Staging` or `Pr
 
 You also need to have RBAC karma to be able to [escalate roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping) for `Role` and/or `ClusterRole` permissions.
 
-Then to install the Environment Controller use [jx create addon envctl](/commands/jx_create_addon_environment/). 
+Then to install the Environment Controller use [jx create addon envctl](/commands/jx_create_addon_environment/).
 
-You need to specify the environments git repository and docker registry host and on GCP the project ID: 
+You need to specify the environments git repository and docker registry host and on GCP the project ID:
 
-``` 
+```sh
 jx create addon envctl -s https://github.com/myorg/env-production.git --project-id myproject --docker-registry gcr.io --cluster-rbac true --user mygituser --token mygittoken
 ```
 
 The installer needs a user + API token for the git repository which it will prompt you for the known values from your `~/.jx/gitAuth.yaml` file so if you already installed Jenkins X it should be able to default those values for you.
 
-If you prefer you can install the helm chart `jenkins-x/environment-controller` directly with helm by specifying the [required values from the values.yaml file](https://github.com/jenkins-x-charts/environment-controller/blob/master/environment-controller/values.yaml#L3-L19) 
+If you prefer you can install the helm chart `jenkins-x/environment-controller` directly with helm by specifying the [required values from the values.yaml file](https://github.com/jenkins-x-charts/environment-controller/blob/master/environment-controller/values.yaml#L3-L19)
 
 
 ## Installing Ingress Controller
@@ -81,7 +81,7 @@ If you don't already have any kind of Ingress Controller in your remote `Staging
 
 To install the default ingress controller into a remote cluster (which doesn't have Jenkins X installed) you can use the command [jx create addon ingctl](/commands/jx_create_addon_ingress/)
 
-``` 
+```sh
 jx create addon ingctl
 ```
 
@@ -108,13 +108,13 @@ The following things are not yet automatically configured for you but we hope to
 
 * currently you have to manually add the `CHART_REPOSITORY` environment variable into the `jenkins-x.yml` file in your environment git repository. e.g. a `jenkins-x.yml` file like this will do the trick - using the real URL to your chartmuseum (use `jx open` in your development cluster:
 
-```yaml 
+```yaml
 pipelineConfig:
   env:
   - name: CHART_REPOSITORY
     value: http://chartmuseum.jx.1.2.3.4.nip.io
  ```
- 
+
 You can do the above via the [jx create var -n CHART_REPOSITORY](/commands/jx_create_variable/) command if you are inside a clone of the staging/production git repository - then git commit + merge the change.
 
 

--- a/content/en/docs/reference/preview.md
+++ b/content/en/docs/reference/preview.md
@@ -6,12 +6,12 @@ weight: 50
 ---
 
 We highly recommend the use of [Preview Environments](/docs/concepts/features/#preview-environments) to get early feedback on changes to applications before the changes are merged into master.
-  
+
 Typically the creation of preview environments is automated inside the Pipelines created by Jenkins X.
 
 However you can manually create a [Preview Environment](/docs/concepts/features/#preview-environments) using [jx](/commands/jx) via the [jx preview](/commands/jx_preview) command.
 
-```shell 
+```sh
 jx preview
 ```
 
@@ -20,15 +20,15 @@ jx preview
 * a new [Environment](/docs/concepts/features/#environments) of kind `Preview` is created along with a [kubernetes namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) which shows up in the [jx get environments](/commands/jx_get_environments/) command along with the [jx environment and jx namespace commands](/developing/kube-context) so you can see which preview environments are active and switch into them to look around
 * the Pull Request is built as a preview docker image and chart and deployed into the preview environment
 * a comment is added to the Pull Request to let your team know the preview application is ready for testing with a link to open the application. So in one click your team members can try out the preview!
- 
+
 <img src="/images/pr-comment.png" class="img-thumbnail">
 
 
-## Adding more resources 
+## Adding more resources
 
 Its common when creating, for example, a web front end to need a backend or database to work from to verify that the microservice works.
 
-For each application the preview environment is defined by a helm chart at: `charts/preview/Chart.yaml`. 
+For each application the preview environment is defined by a helm chart at: `charts/preview/Chart.yaml`.
 
 ## Charts
 
@@ -36,7 +36,7 @@ So you can easily add any dependent helm charts to your preview environment by a
 
 You can find possible charts to install by searching helm. e.g. to find a `postgresql` chart try:
 
-``` 
+```
 helm search postgres
 ```
 
@@ -72,14 +72,14 @@ Note: `- alias: preview` must be last entry in dependecies array and `requiremen
 
 If you need any additional resources like `ConfigMap`, `Secret` or `Service` resources you can add them to `charts/preview/templates/*.yaml`.
 
-You can always _service link_ from the Preview Environment namespace to other namespaces by creating a `Service` with an `externalName` which links to a `Service` running in another namespace (such as Staging or Production) or to point to a service running outside of the Kubernetes cluster completely. 
+You can always _service link_ from the Preview Environment namespace to other namespaces by creating a `Service` with an `externalName` which links to a `Service` running in another namespace (such as Staging or Production) or to point to a service running outside of the Kubernetes cluster completely.
 
 We have a command [jx step service link](/commands/jx_step_link/) which does this for you:
 
 ```
 jx step link services --from-namespace jx-staging --includes "*" --excludes "cheese*"
  ```
- 
+
 ### Configuration
 
 If you need to tweak your application when running in a Preview Environment you can add custom settings to the `charts/preview/values.yaml`file
@@ -88,27 +88,27 @@ If you need to tweak your application when running in a Preview Environment you 
 
 One of the extension points of Jenkins X lets you put a hook in after a preview job has been deployed. This hook applies to all apps in a team even existing ones, for all new pull requests/changes. (You don't have to add it to each pipeline by hand - it can be used to enforce best practices).
 
-This means you can run a container Job against the preview app, validating it, before the CI pipeline completes. Should this Job fail, the pull request will be marked as a failure. 
+This means you can run a container Job against the preview app, validating it, before the CI pipeline completes. Should this Job fail, the pull request will be marked as a failure.
 
-Here is an example: 
+Here is an example:
 
 ```
 jx create post preview job --name owasp --image owasp/zap2docker-weekly:latest -c "zap-baseline.py" -c "-I" -c "-t" -c "\$(JX_PREVIEW_URL)"
 ```
 
-This creates a post preview job which runs the `zap-baseline.py` command inside the specified docker image (it will pull the image and run it, and then shut it down) which scans the running preview app for any problems. 
+This creates a post preview job which runs the `zap-baseline.py` command inside the specified docker image (it will pull the image and run it, and then shut it down) which scans the running preview app for any problems.
 
-The `$JX_PREVIEW_URL` environment variable is made available in case the job needs to access the running preview app. Use `-c` to pass commands to the container. 
+The `$JX_PREVIEW_URL` environment variable is made available in case the job needs to access the running preview app. Use `-c` to pass commands to the container.
 
-This job runs after the preview has been deployed. If it returns non zero, the PR will be marked as a failure. 
+This job runs after the preview has been deployed. If it returns non zero, the PR will be marked as a failure.
 
-You can also run: 
+You can also run:
 
 ```
 jx get post preview
 ```
 
-to list any configured post preview jobs, and: 
+to list any configured post preview jobs, and:
 
 ```
 jx delete post preview job --name=NAME_HERE

--- a/content/en/docs/using-jx/creating/create-camel.md
+++ b/content/en/docs/using-jx/creating/create-camel.md
@@ -8,16 +8,16 @@ weight: 20
 If you want to create a new Spring Boot based microservice using [Apache Camel](http://camel.apache.org/) you can use the [jx create camel](/commands/jx_create_camel) command.
 
 
-```shell
-$ jx create camel
+```sh
+jx create camel
 ```
 
 You are then prompted for the project name.
 
 If you want you can specify this on the command line:
 
-```shell
-$ jx create camel -a myapp
+```sh
+jx create camel -a myapp
 ```
 
 
@@ -26,7 +26,7 @@ $ jx create camel -a myapp
 Once you have chosen the project to create and given it a name the following is automated for you:
 
 * creates a new camel microservice in a sub directory
-* add your source code into a git repository 
+* add your source code into a git repository
 * create a remote git repository on a git service, such as [GitHub](https://github.com)
 * push your code to the remote git service
 * adds default files:
@@ -35,4 +35,4 @@ Once you have chosen the project to create and given it a name the following is 
   * helm chart to run your application inside Kubernetes
 * register a webhook on the remote git repository to your teams Jenkins
 * add the git repository to your teams Jenkins
-* trigger the first pipeline 
+* trigger the first pipeline

--- a/content/en/docs/using-jx/creating/create-mlquickstart.md
+++ b/content/en/docs/using-jx/creating/create-mlquickstart.md
@@ -10,15 +10,15 @@ Machine learning quickstarts are pre-made machine-learning applications you can 
 You can create new applications from our list of curated machine learning quickstart applications via the [jx create mlquickstart](/commands/jx_create_mlquickstart) command.
 
 
-```shell
-$ jx create mlquickstart
+```sh
+jx create mlquickstart
 ```
 
 You are then prompted for a list of quickstarts to choose from.
 
 You will see that these come in groups of three:
 
-```shell
+```sh
 ? select the quickstart you wish to create  [Use arrows to move, space to select, type to filter]
 > machine-learning-quickstarts/ML-python-pytorch-cpu
   machine-learning-quickstarts/ML-python-pytorch-cpu-service
@@ -41,8 +41,8 @@ If you create these individually, it is important that your projects share the s
 
 You can use a text filter to filter on the project names:
 
-```shell
-$ jx create mlquickstart -f gpu
+```sh
+jx create mlquickstart -f gpu
 ```
 
 ### What happens when you create a quickstart
@@ -66,8 +66,8 @@ Meanwhile the training project will start work on training the model and once tr
 
 You can restart training with the command:
 
-```shell
-$ jx start pipeline
+```sh
+jx start pipeline
 ```
 and then select the name of the training project you wish to run again, or you may edit your training script, commit your changes and push them to automatically trigger another training run.
 
@@ -94,7 +94,7 @@ Then when you create a machine learning quickstart, the [Jenkins X build packs](
   * `Dockerfile` to package the application as a docker image
   * `jenkins-x.yml` to implement the CI / CD pipelines using declarative pipeline as code
   * Helm Charts to deploy the application on Kubernetes and to implement [Preview Environments](/docs/concepts/features/#preview-environments)
-   
+
 ## Adding your own Quickstarts
 
 If you would like to submit a new Quickstart to Jenkins X please just [raise an issue](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20mlquickstart&body=Please%20add%20this%20github%20mlquickstart:) with the URL in GitHub of your quickstart and we can fork it it into the [quickstart organisation](https://github.com/machine-learning-quickstarts) so it appears in the `jx create mlquickstart` menu.
@@ -103,8 +103,8 @@ Or if you are part of an open source project and wish to curate your own set of 
 
 Until we do that you can still use your own Quickstarts in the `jx create mlquickstart` command via the `-g` or `--organisations` command line argument. e.g.
 
-```shell
-$ jx create mlquickstart  --organisations my-github-org
+```sh
+jx create mlquickstart  --organisations my-github-org
 ```
 
 Then all machine learning quickstarts found in `my-github-org` will be listed in addition to the defaults.
@@ -122,7 +122,7 @@ Try to pick explanatory names so that it is clear what language, frameworks and 
 
 Inside your project set repository, create a single file named `projectset` which has the following format:
 
-```
+```yaml
 [
    {
       "Repo":"ML-python-pytorch-cpu-service",
@@ -142,31 +142,31 @@ You can configure at a team level the quickstarts which are presented to you in 
 To add the location of a set of machine learning quickstarts you can use the [jx create quickstartlocation](/commands/jx_create_quickstartlocation/) command.
 
 
-```shell
-$ jx create quickstartlocation --url https://mygit.server.com --owner my-mlquickstarts --includes=[ML-*]
-```  
+```sh
+jx create quickstartlocation --url https://mygit.server.com --owner my-mlquickstarts --includes=[ML-*]
+```
 
 Note that you MUST specify the `--includes=[ML-*]` option or your quickstarts will be added to the conventional quickstart list rather than the machine learning list.
 
 If you omit the `--url` argument the command will assume its a [GitHub](https://github.com/) repository. Note that both public and private repositories are supported.
 
-This means you can have your own shared private quickstarts to reuse within your organisation. Of course we'd obviously prefer you to [share your quickstarts with us via open source](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20mlquickstart&body=Please%20add%20this%20github%20mlquickstart:) then we can include your quickstart with the entire [community](/community) - but there may be times you want to curate your own internal quickstarts using proprietary software. 
+This means you can have your own shared private quickstarts to reuse within your organisation. Of course we'd obviously prefer you to [share your quickstarts with us via open source](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20mlquickstart&body=Please%20add%20this%20github%20mlquickstart:) then we can include your quickstart with the entire [community](/community) - but there may be times you want to curate your own internal quickstarts using proprietary software.
 
-You can also specify other `--includes` or `--excludes` patterns to filter the names of the repositories where `*` matches anything and `foo*` matches anything starting with `foo`. e.g. you could just include the languages and technologies your organisation supports and exclude the rest etc. 
+You can also specify other `--includes` or `--excludes` patterns to filter the names of the repositories where `*` matches anything and `foo*` matches anything starting with `foo`. e.g. you could just include the languages and technologies your organisation supports and exclude the rest etc.
 
 Also note that you can use the alias of `qsloc` instead of `quickstartlocation` if you like shorter aliases ;)
 
 You can then view the current quickstart locations for your team via the [jx get quickstartlocations](/commands/jx_get_quickstartlocations/) command:
 
-```shell
-$ jx get quickstartlocations
-```  
+```sh
+jx get quickstartlocations
+```
 
 Or using an abbreviation
-  
-```shell
-$ jx get qsloc
-```  
-  
-There is also [jx delete quickstartlocation](/commands/jx_delete_quickstartlocation/) if you need to remove a git organisation.  
-                                                                                                 
+
+```sh
+jx get qsloc
+```
+
+There is also [jx delete quickstartlocation](/commands/jx_delete_quickstartlocation/) if you need to remove a git organisation.
+

--- a/content/en/docs/using-jx/creating/create-spring.md
+++ b/content/en/docs/using-jx/creating/create-spring.md
@@ -42,13 +42,13 @@ chart for running as a package in Kubernetes.
 
 1.  Change into your Spring Boot project directory:
 
-```shell
+```sh
 cd my-springapp/
 ```
 
 2.  Run the import from a command-line:
 
-```shell
+```sh
 jx import
 ```
 
@@ -72,7 +72,7 @@ If you are evaluating Spring Boot in your Jenkins X environment and need an appl
 
 1.  Run the Spring Boot creation via command-line:
 
-```shell
+```sh
 jx create spring
 ```
 
@@ -103,8 +103,8 @@ There is a [demo of using the command: jx create spring](/demos/create_spring/).
 
 You can also pass certain options to the `jx create` command, such as specifying Spring Boot dependencies:
 
-```shell
-$ jx create spring -d web -d actuator
+```sh
+jx create spring -d web -d actuator
 ```
 
 The `-d` argument lets you specify the Spring Boot dependencies you wish to add to your spring boot application. In the above example, the command calls the `web` argument, which passes in the Web Starter dependency to create RESTful web applications; the `actuator` dependency for monitoring the health and metrics your application.  When you omit the `-d` arguments and let the `jx` command prompt you to pick the dependencies via a CLI wizard

--- a/content/en/docs/using-jx/creating/import.md
+++ b/content/en/docs/using-jx/creating/import.md
@@ -7,9 +7,9 @@ weight: 70
 
 If you already have some source code you wish to import into Jenkins X then you can use the [jx import](/commands/jx_import) command. e.g.
 
-```shell
-$ cd my-cool-app
-$ jx import
+```sh
+cd my-cool-app
+jx import
 ```
 
 Import will perform the following actions (prompting you along the way):
@@ -23,43 +23,43 @@ Import will perform the following actions (prompting you along the way):
   * helm chart to run your application inside Kubernetes
 * register a webhook on the remote git repository to your teams Jenkins
 * add the git repository to your teams Jenkins
-* trigger the first pipeline 
+* trigger the first pipeline
 
 ### Avoiding docker + helm
 
 If you are importing a repository that does not create a docker image you can use the `--no-draft` command line argument which will not use Draft to default the Dockerfile and helm chart.
- 
+
 
 ### Importing via URL
 
 If you wish to import a project which is already in a remote git repository then you can use the `--url`  argument:
 
-```shell
-$ jx import --url https://github.com/jenkins-x/spring-boot-web-example.git
+```sh
+jx import --url https://github.com/jenkins-x/spring-boot-web-example.git
 ```
 
 ### Importing GitHub projects
 
 If you wish to import projects from a github organisation you can use:
- 
-```shell
-$ jx import --github --org myname
+
+```sh
+jx import --github --org myname
 ```
 
 You will be prompted for the repositories you wish to import. Use the cursor keys and space bar to select/deselect the repositories to import.
 
 If you wish to default all repositories to be imported (then deselect any you don't want add `--all`:
-   
-```shell
-$ jx import --github --org myname --all
+
+```sh
+jx import --github --org myname --all
 ```
 
 To filter the list you can add a `--filter`
 
-```shell
-$ jx import --github --org myname --all --filter foo
-```  
-  
+```sh
+jx import --github --org myname --all --filter foo
+```
+
 ## Branch patterns
 
 When importing projects into Jenkins X we use git branch patterns to determine which branch names are automatically setup for CI/CD.
@@ -69,29 +69,29 @@ Typically that may default to something like `master|PR-.*|feature.*`. That mean
 If you use another branch name than `master` such as `develop` or whatever you can change this pattern to be whatever you you like via the `--branches` argument whenever you run [jx import](/commands/jx_import), [jx create spring](/commands/jx_create_spring) or [jx create quickstart](/commands/jx_create_quickstart).
 
 
-```shell
-$ jx import --branches "develop|PR-.*|feature.*"
-```  
-  
+```sh
+jx import --branches "develop|PR-.*|feature.*"
+```
+
 You may wish to set this to just `.*` to work with all branches,.
 
-```shell
-$ jx import --branches ".*"
-```  
-  
+```sh
+jx import --branches ".*"
+```
+
 ## Configuring your teams branch patterns
 
-Usually a team uses the same naming conventions for branches so you may wish to configure the branch patterns at a team level so that they will be used by default if anyone in your team runs [jx import](/commands/jx_import), [jx create spring](/commands/jx_create_spring) or [jx create quickstart](/commands/jx_create_quickstart). 
+Usually a team uses the same naming conventions for branches so you may wish to configure the branch patterns at a team level so that they will be used by default if anyone in your team runs [jx import](/commands/jx_import), [jx create spring](/commands/jx_create_spring) or [jx create quickstart](/commands/jx_create_quickstart).
 
 These settings are stored in the [Environment Custom Resource](/docs/reference/components/custom-resources/) in Kubernetes.
 
 To set the branch patterns for your team  [jx edit branchpattern](/commands/jx_edit_branchpattern/) command.
 
-```shell
-$ jx edit branchpattern  "develop|PR-.*|feature.*"
-```  
+```sh
+jx edit branchpattern  "develop|PR-.*|feature.*"
+```
 You can then view the current branch patterns for your team via the [jx get branchpattern](/commands/jx_get_branchpattern/) command:
 
-```shell
-$ jx get branchpattern
-```  
+```sh
+jx get branchpattern
+```

--- a/content/en/docs/using-jx/developing/browsing.md
+++ b/content/en/docs/using-jx/developing/browsing.md
@@ -7,20 +7,20 @@ aliases:
   - /developing/browsing
 ---
 
-                
+
 If you have used kubernetes before you're probably used the [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) command line to view kubernetes resources:
 
-```shell
+```sh
 kubectl get pods
 ```
 
 The Jenkins X command line tool, [jx](/commands/jx), has a similar look and feel to [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and lets you get the status of all the Jenkins X resources.
 
 ### View Jenkins Console
- 
+
 If you are familiar with the Jenkins console then you can use [jx console](/commands/jx_console):
 
-```shell
+```sh
 jx console
 ```
 
@@ -30,13 +30,13 @@ to open it in a browser.
 
 To view the current pipeline activity [jx get activities](/commands/jx_get_activities):
 
-```shell
+```sh
 jx get activities
 ```
 
 If you want to watch whats going on with your app `myapp`  you can use:
 
-```shell
+```sh
 jx get activities -f myapp -w
 ```
 
@@ -46,7 +46,7 @@ Which will watch the pipeline activities and update the screen whenever a signif
 
 To view the current pipeline build logs via [jx get build logs](/commands/jx_get_build_logs):
 
-```shell
+```sh
 jx get build logs
 ```
 
@@ -54,13 +54,13 @@ You are then presented with all the possible pipelines to watch.
 
 You can quickly filter that via
 
-```shell
+```sh
 jx get build logs -f myapp
 ```
 
 or if you wish to be explicit
 
-```shell
+```sh
 jx get build logs myorg/myapp/master
 ```
 
@@ -68,7 +68,7 @@ jx get build logs myorg/myapp/master
 
 To view the current configured pipelines use [jx get pipelines](/commands/jx_get_pipelines):
 
-```shell
+```sh
 jx get pipelines
 ```
 
@@ -76,25 +76,25 @@ jx get pipelines
 
 To view all the applications in your team across all your environments with URLs and pod counts use  [jx get applications](/commands/jx_get_applications):
 
-```shell
+```sh
 jx get applications
 ```
 
 If you want to hide the URLs or the pod counts you can use `u` or `-p`. e.g. to hide the URLs:
 
-```shell
+```sh
 jx get applications -u
 ```
 
 Or hide the pod counts:
 
-```shell
+```sh
 jx get applications -p
 ```
 
 You can also filter the apps by an environment:
 
-```shell
+```sh
 jx get applications -e staging
 ```
 
@@ -104,11 +104,11 @@ jx get applications -e staging
 
 To view the [environments](/docs/concepts/features/#environments) defined for your team use [jx get environments](/commands/jx_get_environments):
 
-```shell
+```sh
 jx get environments
 ```
 
-You can also 
+You can also
 
 * create a new environment via [jx create environment](/commands/jx_create_environment)
 * edit an environment via [jx edit environment](/commands/jx_edit_environment)

--- a/content/en/docs/using-jx/developing/devpods.md
+++ b/content/en/docs/using-jx/developing/devpods.md
@@ -5,10 +5,10 @@ description: Using Jenkins X to continuously deliver value to your customers
 weight: 50
 ---
 
-Jenkins X allows you to edit app code by using a Kubernetes Pod which we call `DevPod`.  This helps you develop inside the cloud with the same software tools, platform, container images and pod templates as the CI/CD pipelines. This helps keep everyone in the team and your CI/CD pipelines using the same platform and tools all the time to reduce waste and avoid those pesky 'it works on my laptop but not in production' issues.  
+Jenkins X allows you to edit app code by using a Kubernetes Pod which we call `DevPod`.  This helps you develop inside the cloud with the same software tools, platform, container images and pod templates as the CI/CD pipelines. This helps keep everyone in the team and your CI/CD pipelines using the same platform and tools all the time to reduce waste and avoid those pesky 'it works on my laptop but not in production' issues.
 
 
-There are a couple of ways that you as a developer can quickly become productive when editing an app, and add value ultra fast. 
+There are a couple of ways that you as a developer can quickly become productive when editing an app, and add value ultra fast.
 
 There are specific steps for each approach, and we provide you a visual representation of each workflow, as well as the specific steps to quickly get started.
 
@@ -33,8 +33,8 @@ See [IDE](/docs/using-jx/common-tasks/ide/#vs-code) for more details on using VS
 
 To get started using this approach, simply execute the following command in the root of your app directory.  We are using a `NodeJS` app for this example, therefore we specify the language using the `-l` parameter.
 
-```bash
-  jx create devpod -l nodejs --reuse --sync 
+```sh
+jx create devpod -l nodejs --reuse --sync
 ```
 A successful execution will ensures the following happened:
 
@@ -44,7 +44,7 @@ A successful execution will ensures the following happened:
 
 Once this happens, you must execute one more command within your ssh session to the Pod to ensure any changes are synchronized.
 
-```bash
+```sh
 ./watch.sh
 ```
 
@@ -67,9 +67,9 @@ If you prefer not to use an IDE on your desktop using a similar workflow as abov
 
 Using this approach, you execute the following on your terminal.
 
-```bash
+```sh
 
-jx create devpod --verbose true                                 
+jx create devpod --verbose true
 
 # some output us removed for brevity
 Creating a DevPod of label: nodejs
@@ -103,11 +103,11 @@ A succesful execution of the command above, will ensure the following has happen
 
 To see your changes in real-time, you must also execute the following command within your terminal session connected to the Pod:
 
-```bash
+```sh
 ./watch.sh
 ```
 
-### Promote to Staging 
+### Promote to Staging
 Once you are happy with the changes you made to the app, you can simply check-in your code and create a `pull request`.  This will trigger the pipeline to promote your changes to the `Staging` environment (**Step 2 and 3 in diagram**)
 
 ### Promote to Production
@@ -115,14 +115,16 @@ Most of the time,the Production environment in **Jenkins X** will have its `Prom
 
 To promote the app to production, you can execute the following commands:
 
-```bash
-# first get the app version from this output
-jx get apps
+1. first get the app version from this output
 
-# promote app version 0.0.2 from staging to production
-jx promote --version 0.0.2 --env production
+```sh
+jx get apps
 ```
 
+2. promote app version 0.0.2 from staging to production
 
+```sh
+jx promote --version 0.0.2 --env production
+```
 
 # Additional Learning

--- a/content/en/docs/using-jx/developing/issues.md
+++ b/content/en/docs/using-jx/developing/issues.md
@@ -1,7 +1,7 @@
 ---
 title: Issues
 linktitle: Issues
-description: Working with issues 
+description: Working with issues
 weight: 80
 ---
 
@@ -9,7 +9,7 @@ Jenkins X defaults to using the issue tracker in your git provider for creating 
 
 e.g. if you are inside the source code of a github project then you can type [jx create issue](/commands/jx_create_issue):
 
-```
+```sh
 jx create issue -t "lets make things more awesome"
 ```
 
@@ -17,47 +17,47 @@ And a new issue will be created on github.
 
 You can list open the issues on your project via [jx get issues](/commands/jx_get_issues):
 
-```
+```sh
 jx get issues
 ```
-             
+
 ### Using a different issue tracker
 
 If you wish to use, say, JIRA on a project you first need to add a JIRA service.
 
 You can register your JIRA service via [jx create tracker server](/commands/jx_create_tracker_server):
 
-```
+```sh
 jx create tracker server jira https://mycompany.atlassian.net/
 ```
 
 You can then view your issue tracker server via [jx get tracker](/commands/jx_get_tracker):
 
-```
+```sh
 jx get tracker
 ```
-             
+
 Then add a user and token via:
 
-```
+```sh
 jx create tracker token -n jira  myEmailAddress
 ```
-      
+
 ### configure the issue tracker on a project
 
 In the source code of your project then use [jx edit config](/commands/jx_edit_config):
 
-```
+```sh
 jx edit config -k issues
-```  
-           
-Then 
+```
+
+Then
 
 * if you have multiple issue trackers, pick the one you wish to use for the project
 * enter the name of the project in the issue tracker (e.g. the upper case name of the JIRA project)
 
-A file called `jenkins-x.yml` will be modified in your project source code which should be added to your git repository. 
- 
+A file called `jenkins-x.yml` will be modified in your project source code which should be added to your git repository.
+
 
 
 

--- a/content/en/docs/using-jx/developing/kube-context.md
+++ b/content/en/docs/using-jx/developing/kube-context.md
@@ -11,7 +11,7 @@ The kubernetes CLI tool [kubectl](https://kubernetes.io/docs/reference/kubectl/o
 
 If you want to change the namespace using the kubectl command line you can use:
 
-```shell
+```sh
 kubectl config set-context `kubectl config current-context` --namespace=foo
 ```
 
@@ -21,72 +21,72 @@ However [jx](/commands/jx) provides lots of helper commands for changing cluster
 
 Use [jx environment](/commands/jx_environment) to switch [environments](/docs/concepts/features/#environments)
 
-```shell
+```sh
 jx environment
 ```
 
 You will be presented with a list of the environments for the current team. Use the cursor keys and enter to select the one you wish to switch to. Or press `Ctrl+C` to terminate and not change the environment.
 
 Or if you know the environment you wish to switch to just type it as an argument:
- 
-```shell
+
+```sh
 jx env staging
 ```
 
 ### Changing Namespace
 
-Use [jx namespace](/commands/jx_namespace) to switch between different kubernetes namespaces. 
+Use [jx namespace](/commands/jx_namespace) to switch between different kubernetes namespaces.
 
 
-```shell
+```sh
 jx namespace
 ```
 
 You will be presented with a list of all the namespaces in the kubernetes cluster. Use the cursor keys and enter to select the one you wish to switch to. Or press `Ctrl+C` to terminate and not change the namespace.
 
 Or if you know the kubernetes namespace you wish to switch to just type it as an argument:
- 
-```shell
+
+```sh
 jx ns jx-production
 ```
 
 ### Changing Cluster
 
-Use [jx context](/commands/jx_context) to switch between different kubernetes clusters (or contexts). 
+Use [jx context](/commands/jx_context) to switch between different kubernetes clusters (or contexts).
 
 
-```shell
+```sh
 jx context
 ```
 
 You will be presented with a list of all the contexts that you have used on your machine. Use the cursor keys and enter to select the one you wish to switch to. Or press `Ctrl+C` to terminate and not change the namespace.
 
 Or if you know the kubernetes namespace you wish to switch to just type it as an argument:
- 
-```shell
+
+```sh
 jx ctx gke_jenkinsx-dev_europe-west2-a_myuserid-foo
 jx ctx minikube
 ```
 
 ### Local changes
 
-When you change namespace or context in kubernetes via [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) or the commands above then the kubernetes context and namespace is changed for **all of your terminals** as it updates the shared file (`~/.kube/config` or `$KUBECONFIG`). 
+When you change namespace or context in kubernetes via [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) or the commands above then the kubernetes context and namespace is changed for **all of your terminals** as it updates the shared file (`~/.kube/config` or `$KUBECONFIG`).
 
 This can be handy - but is sometimes dangerous. e.g. if you want to do something on a production cluster; but forget and then re-run a command in another terminal to delete all the pods in your development namespace - but forget you just switched to the production namespace!
- 
+
  So its sometimes useful to be able to change the kubernetes context and/or namespace locally in a single shell only. For example if you ever want to look at a production cluster, only use that cluster in one shell only to minimise accidents.
- 
- You can do that with the [jx shell](/commands/jx_shell) command which prompts you to pick a different kubernetes context like the  [jx context](/commands/jx_context) command. However changes to the namespace and/or cluster made in this shell only affect the current shell only! 
- 
+
+ You can do that with the [jx shell](/commands/jx_shell) command which prompts you to pick a different kubernetes context like the  [jx context](/commands/jx_context) command. However changes to the namespace and/or cluster made in this shell only affect the current shell only!
+
 [jx shell](/commands/jx_shell) also automatically updates your command prompt using [jx prompt](/commands/jx_prompt)
 so that it is clear your shell has changed the context and/or namespace,
 and adds bash completion via [jx prompt](/commands/jx_prompt).
- 
-### Customise your shell
+
+### Customize your shell
 
 You can use [jx prompt](/commands/jx_prompt)  to add the current kubernetes cluster and namespace to your terminals prompt.
 
-To add bash completion to your shell for [jx commands](/commands/jx) then try the  [jx completion](/commands/jx_completion).  
+To add bash completion to your shell for [jx commands](/commands/jx) then try the  [jx completion](/commands/jx_completion).
 
 
 

--- a/content/en/docs/using-jx/faq/_index.md
+++ b/content/en/docs/using-jx/faq/_index.md
@@ -3,7 +3,7 @@ title: FAQ
 linktitle: FAQ
 description: Questions on how to develop cloud native application with Jenkins X
 weight: 40
-aliases: 
+aliases:
   - /faq/
 ---
 
@@ -52,22 +52,22 @@ Though a nicer approach would be using a Vault operator which we’re investigat
 
 We have a background garbage collection job which removes Preview Environments after the Pull Request is closed/merged. You can run it any time you like via the [jx gc previews](/commands/jx_gc_previews/) command
 
-```
+```sh
 jx gc previews
 ```
 
 You can also view the current previews via  [jx get previews](/commands/jx_get_previews/):
 
-  ```
-  jx get previews
-  ```
+```sh
+jx get previews
+```
 
 
 and delete a preview by choosing one to delete via [jx delete preview](/commands/jx_delete_preview/):
 
- ```
- jx delete preview
- ```
+```sh
+jx delete preview
+```
 
 ## How do I add other services into a Preview?
 
@@ -90,11 +90,11 @@ For Tekton we use the [prow](/docs/reference/components/prow/) / [lighthouse](/d
 
 If you are using [boot](/docs/getting-started/setup/boot/) to install Jenkins X then you can create your own custom `Scheduler` custom resource in `env/templates/myscheduler.yaml` based on the [default one that is included](https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/templates/default-scheduler.yaml).
 
-e.g. here is how we specify the [branches used to create releases](https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/templates/default-scheduler.yaml#L48).  
+e.g. here is how we specify the [branches used to create releases](https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/templates/default-scheduler.yaml#L48).
 
 You can also create additional pipeline contexts; e.g. here's how we add multiple parallel testing pipelines on the [version stream](/docs/concepts/version-stream/) via a [custom Scheduler](https://github.com/jenkins-x/environment-tekton-weasel-dev/blob/master/env/templates/jx-versions-scheduler.yaml#L21) so that we can have many integration tests run in parallel on a single PR. Then each named context listed has an associated `jenkins-x-$context.yml` file in the source repository to define the pipeline to run [like this example which defines the `boot-lh` context](https://github.com/jenkins-x/jenkins-x-versions/blob/master/jenkins-x-boot-lh.yml)
 
-You can then associate your `SourceRepository` resources with your custom scheduler by: 
+You can then associate your `SourceRepository` resources with your custom scheduler by:
 
 * specifying the scheduler name on the `spec.scheduler.name` property of your `SourceRepository` via `kubectl edit sr my-repo-name`)
 * specifying the scheduler name when you import a project via `jx import --scheduler myname`
@@ -153,7 +153,7 @@ If you use [serverless apps](/docs/managing-jx/tutorials/serverless-apps/) with 
 
 You can work around this by manually editing the _knative_ config via:
 
-```
+```sh
 kubectl edit cm config-domain --namespace knative-serving
 ```
 
@@ -231,13 +231,13 @@ See how to [add a custom step to your pipeline](/docs/concepts/jenkins-x-pipelin
 
 By default, [enabling Vault](/docs/getting-started/setup/boot/#vault) via `jx boot`'s `jx-requirements.yaml` will only activate it in your pipeline and preview environments, not in staging and production. To also activate it in those environments, simply add a `jx-requirements.yaml` file to the root of their repo, with at least the following content:
 
-```
+```yaml
 secretStorage: vault
 ```
 
 Then, assuming you have a secret in Vault with path `secret/path/to/mysecret` containing key `password`, you can inject it into service `myapp` (for instance, as a `PASSWORD` environment variable) by adding the following to your staging repo's `/env/values.yaml`:
 
-```
+```yaml
 myapp:
   env:
     PASSWORD: vault:path/to/mysecret:password
@@ -247,7 +247,7 @@ Notice the prefixing with `vault:` URL scheme and also that we omit first path c
 
 If your secret is not environment-specific, you can also inject it directly into your app's `/charts/myapp/values.yaml`:
 
-```
+```yaml
 env:
   PASSWORD: vault:path/to/mysecret:password
 ```
@@ -258,7 +258,7 @@ However, note that this value would be overriden at the environment level if the
 
 Vault does not need to be explicitly enabled for preview environment. To inject same secret as above into your preview, simply add the following to your app's `/charts/preview/values.yaml`:
 
-```
+```yaml
 preview:
   env:
     PASSWORD: vault:path/to/mysecret:password
@@ -270,7 +270,7 @@ When you inject secrets directly into environment variables, they appear in Depl
 
 For example, start by injecting the secret into your staging repo's `/env/values.yaml`:
 
-```
+```yaml
 myapp
   mysecrets:
     password: vault:path/to/mysecret:password
@@ -278,7 +278,7 @@ myapp
 
 Then, in your app's `/charts/myapp/templates`, create a `mysecrets.yaml` file, in which you refer to the secret you just added:
 
-```
+```yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -291,21 +291,21 @@ Notice how we encode the secret value in Base64, as this is the format expected 
 
 Also, make sure to add a default value for the same key in your app's `/charts/myapp/values.yaml`:
 
-```
+```yaml
 mysecrets:
   password: ""
 ```
 
 That allows Helm to resolve to some value during linting of your `mysecrets.yaml`, as linting seems not to consider values from the environment. Otherwise, you might get something like:
 
-```
+```sh
 error: failed to build dependencies for chart from directory '.': failed to lint the chart '.': failed to run 'helm lint --values values.yaml' command in directory '.', output: '==> Linting .
 [ERROR] templates/: render error in "myapp/templates/secrets.yaml": template: myapp/templates/secrets.yaml:6:21: executing "myapp/templates/secrets.yaml" at <.Values.mysecrets.password>: nil pointer evaluating interface {}.password
 ```
 
 Finally, mount the Secret yaml as environment variables in your app's `/charts/myapp/templates/deployment.yaml`:
 
-```
+```yaml
 ...
     spec:
       containers:

--- a/content/en/docs/using-jx/faq/chatops.md
+++ b/content/en/docs/using-jx/faq/chatops.md
@@ -11,11 +11,11 @@ We use the phrase _ChatOps_ to mean operating code changes and GitOPs promotion 
 
 ## What are the benefits of ChatOps?
 
-ChatOps helps developers collaborate on Pull Requests and speeds up merging of Pull Requests. We want to be able to merge changes as quickly as possible into master so that we continuously integrate code which minimises the downsides of long term feature branching and merge hell. 
+ChatOps helps developers collaborate on Pull Requests and speeds up merging of Pull Requests. We want to be able to merge changes as quickly as possible into master so that we continuously integrate code which minimises the downsides of long term feature branching and merge hell.
 
-ChatOps (and [tide in particular](#what-does-hook-do)) also helps automate and speeds up tasks e.g. 
+ChatOps (and [tide in particular](#what-does-hook-do)) also helps automate and speeds up tasks e.g.
 
-* developers don't have to keep hitting reload on a Pull Request page waiting for all the tests to pass so that they can click `Merge`. Just add a `/lgtm` comment or approve the code review and the Pull Request will automatically get merged once its tests go green. This also avoids developers accidentally hitting `Merge` before all the test pass! 
+* developers don't have to keep hitting reload on a Pull Request page waiting for all the tests to pass so that they can click `Merge`. Just add a `/lgtm` comment or approve the code review and the Pull Request will automatically get merged once its tests go green. This also avoids developers accidentally hitting `Merge` before all the test pass!
 * all Pull Request are automatically rebased and tested against master before merging - further ensuring we don't accidentally break master
 * batch merging of Pull Request is supported to speed up merging Pull Requests.
 
@@ -37,33 +37,33 @@ For more detail see [what does tide do](#what-does-hook-do)
 * if a Pull Request has passed all of its review + CI tests (e.g. its got the `approved` and/or `lgtm` labels applied or has passed a github code review) and is green and is based off of master it is automatically merged.
 * if a Pull Request has passed all of its review + CI tests but is not based off of master its pipelines are re-triggered based off of master to ensure the Pull Request will be valid if it were merged.
 * if batching is enabled and there are multiple pending Pull Requests which are approved and green, a batch pipeline is triggered which combines multiple Pull Requests together into a single change - if all those pipelines go green then all the PRs are merged together at once and closed. This greatly speeds up getting multiple Pull Requests merged together (as it avoids re-triggering each PR's tests after each one is merged).
- 
+
 ## How can I make ChatOps HA?
 
 To make ChatOps highly avialable scale up the deployments which listen for http requests to, say, 3 replicas.
 
 When using [Lighthouse](/architecture/lighthouse/) that just means modifying the replicas for the `lighthouse` deployment. e.g. in your [boot](/docs/getting-started/setup/boot/) git repository try changing `env/lighthouse/values.tmpl.yaml` to:
 
-```yaml 
+```yaml
 replicaCount: 3
-``` 
- 
- 
+```
+
+
 When using [Prow](/docs/reference/components/prow/) you need to scale up `hook` and `pipelinerunner`. e.g. in your [boot](/docs/getting-started/setup/boot/) git repository try changing `env/prow/values.tmpl.yaml` to:
 
-```yaml      
+```yaml
 hook:
   replicaCount: 3
 pipelinerunner:
   replicaCount: 3
-``` 
+```
 
 
 ## Should I use prow or lighthouse?
 
 If you are using a git server other than https://github.com then we recommend [Lighthouse](/architecture/lighthouse/).
 
-If you are using https://github.com then for your git server then for now we recommend [Prow](/docs/reference/components/prow/) as it has had more testing than [Lighthouse](/architecture/lighthouse/). 
+If you are using https://github.com then for your git server then for now we recommend [Prow](/docs/reference/components/prow/) as it has had more testing than [Lighthouse](/architecture/lighthouse/).
 
 Though [Lighthouse](/architecture/lighthouse/) is our strategic direction. We are starting to incrementally move our open source repositories over to [Lighthouse](/architecture/lighthouse/). At some point in the future once we've been using [Lighthouse](/architecture/lighthouse/) in production for all of our open source and commercial repositories [Lighthouse](/architecture/lighthouse/) will become our recommended solution for all git providers so that we can have a single, simpler & smaller codebase to maintain.
 
@@ -75,7 +75,7 @@ If you have a pending Pull Request which is blocked on a flaky test or an incorr
 
 [Prow](/docs/reference/components/prow/) and [Lighthouse](/architecture/lighthouse/) use an `OWNERS` file stored in each git repository to define which developers are allowed to review and approve changes. You can even limit those roles to different folders.
 
-If a non-reviewer submits a Pull Request it won't trigger CI pipelines by default until a reviewer adds an `/ok-to-test` comment on the Pull Request. 
+If a non-reviewer submits a Pull Request it won't trigger CI pipelines by default until a reviewer adds an `/ok-to-test` comment on the Pull Request.
 
 If you have public git repositories this also avoids the security issue of a non-approver submitting a Pull Request to change the pipeline to email them your security credentials in the CI pipeline ;)
 

--- a/content/zh/docs/Concepts/features.md
+++ b/content/zh/docs/Concepts/features.md
@@ -73,6 +73,6 @@ Jenkins X 允许你给 Pull Requests 设置一个预发环境，这样就可以�
 
 要安装插件的话，使用命令[jx create addon](/commands/jx_create_addon/)。例如：
 
-```
+```sh
 jx create addon grafana
 ```

--- a/content/zh/docs/Reference/preview.md
+++ b/content/zh/docs/Reference/preview.md
@@ -6,12 +6,12 @@ description: 在变更合并到 master 之前预览 Pull Requests
 
 
 我们强烈建议使用 [预览环境](/zh/docs/concepts/features/#preview-environments) ，使得在变更合并到 master 之前尽快地得到反馈。
-  
+
 通常，预览环境是由 Jenkins X 的流水线中自动创建的。
 
 然而，你可以使用 [jx](/commands/jx) 通过命令 [jx preview](/commands/jx_preview) 手动创建一个[预览环境](/zh/docs/concepts/features/#preview-environments)。
 
-```shell 
+```sh
 jx preview
 ```
 
@@ -20,7 +20,7 @@ jx preview
 * 一个新的 [环境](/zh/docs/concepts/features/#environments) ，例如 `预览` 被创建时，一个 [kubernetes 命名空间](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 会在 [jx get environments](/commands/jx_get_environments/) 出现， 使用 [jx 环境和 jx 命名空间命令](/zh/developing/kube-context) 你可以看到那个预览环境是活跃的，并可以进入查看。
 * Pull Request 会作为预览 Docker 镜像和 chart 构建，并被部署到预览环境中
 * 添加一条注释到 Pull Request 中，让你们团队知道该预览应用已经准备好可以测试了，并带有打开应用的链接。因此，只要点击一下就可以让你们团队成员体验预览环境！
- 
+
 <img src="/images/pr-comment.png" class="img-thumbnail">
 
 

--- a/content/zh/docs/contributing/code/_index.md
+++ b/content/zh/docs/contributing/code/_index.md
@@ -34,20 +34,20 @@ Go 语言环境的安装仅需要几分钟。并且多种方式可供选择。
 
 安装完成后，确认是否一切工作正常。打开一个新的终端或者在 Windows 上的命令行并输入:
 
-```
+```sh
 go version
 ```
 
 在终端的窗口上可以看到类似如下的信息。注意 `version` 表示的是在在更新此文档时最新的 Go 的版本信息:
 
-```
+```sh
 go version go1.8 darwin/amd64
 ```
 
 下一步，确保[根据安装文档][setupgopath] 设置了 `GOPATH` 环境变量。
 通过 `echo $GOPATH` 输出 `GOPATH`。应该是指向了你的合法的 Go 的工作目录的非空字符串，如:
 
-```
+```sh
 /Users/<yourusername>/Code/go
 ```
 
@@ -55,7 +55,7 @@ go version go1.8 darwin/amd64
 
 如果你是 MacOS 用户并且安装了 [Homebrew](https://brew.sh/)，安装过程将会很简单，在终端中执行以下命令:
 
-```
+```sh
 brew install go
 ```
 
@@ -90,19 +90,19 @@ Go 提供了 `get` 的子命令来帮助下载软件包以配置工作环境。�
 
 在 Mac 系统上，可以通过 [Homebrew](https://brew.sh) 来安装 [Hub](https://github.com/github/hub)：
 
-```
+```sh
 brew install hub
 ```
 
 安装之后，在 Bash 中创建[快捷键](http://tldp.org/LDP/abs/html/aliases.html)，以方便我们在执行 `git` 的时候，实际上执行的是 `hub`:
 
-```
+```sh
 echo "alias git='hub'" >> ~/.bash_profile
 ```
 
 确认安装配置是否正确：
 
-```
+```sh
 git version 2.6.3
 hub version 2.2.2
 ```
@@ -121,13 +121,13 @@ hub version 2.2.2
 
 首先，我们克隆主版本库：
 
-```
+```sh
 go get -v -u github.com/jenkins-x/jx
 ```
 
 Jenkins X 使用 [Testify](https://github.com/stretchr/testify) 进行 Go 代码的测试。如果还没有安装的话，使用下面的方式获得 Testify 测试工具：
 
-```
+```sh
 go get github.com/stretchr/testify
 ```
 
@@ -148,20 +148,20 @@ go get github.com/stretchr/testify
 
 切换到命令窗口中，进入到刚才所克隆的主版本库的工作目录当中。
 
-```
+```sh
 cd $GOPATH/src/github.com/jenkins-x/jx
 ```
 
 现在 Git 需要知道我们刚刚创建出来的分之仓库的地址信息
 
-```
+```sh
 git remote add <YOUR-GITHUB-USERNAME> <COPIED REMOTE-URL>
 ```
 
 #### 使用 Hub 派生
 
 相类似的，可以使用 Git 的封装工具 Hub 进行操作。Hub 使得创建分之仓库变得容易：
-```
+```sh
 git fork
 ```
 
@@ -171,13 +171,13 @@ git fork
 
 让我们通过列出所有已有的 remote 来检查是否一切就绪：
 
-```
+```sh
 git remote -v
 ```
 
 输出应该类似如下内容：
 
-```
+```sh
 digitalcraftsman    git@github.com:digitalcraftsman/hugo.git (fetch)
 digitalcraftsman    git@github.com:digitalcraftsman/hugo.git (push)
 origin  https://github.com/jenkins-x/jx (fetch)
@@ -192,13 +192,13 @@ origin  https://github.com/jenkins-x/jx (push)
 
 首先， 你需要获取在主版本上进行的最新的内容：
 
-```
+```sh
 git checkout master
 git pull
 ```
 现在，为你的附加功能创建一个新的版本：
 
-```
+```sh
 git checkout -b <BRANCH-NAME>
 ```
 
@@ -216,7 +216,7 @@ git checkout -b <BRANCH-NAME>
 
 在代码库上进行更改的同时，创建相应的二进制文件来进行测试是很好的方法：
 
-```
+```sh
 go build -o hugo main.go
 ```
 
@@ -229,13 +229,13 @@ go build -o hugo main.go
 
 Go 语言的代码格式也许根据人的意识会有所不同，但是不论是由谁编写的代码，Go 本身会确保代码看上去一致。Go 提供了格式化工具，使我们的修改风格统一：
 
-```
+```sh
 go fmt ./...
 ```
 
 如果进行了修改，请确保遵循我们的[代码贡献指导说明](https://github.com/jenkins-x/jx/blob/master/CONTRIBUTING.MD)。
 
-```
+```sh
 # Add all changed files
 git add --all
 git commit --message "YOUR COMMIT MESSAGE"
@@ -253,20 +253,20 @@ git commit --message "YOUR COMMIT MESSAGE"
 
 让我们以你想要修改最后的一次提交信息为例。执行下面的命令以替换之前的提交信息：
 
-```
+```sh
 git commit --amend -m"新的提交信息"
 ```
 
 检查历史提交记录，查询修改信息：
 
-```
+```sh
 git log
 # 输入 q 退出
 ```
 
 在做了最后的修改后，你也许忘记了什么。没有必要创建新的提交。只需要将最新的修改添加到 Git 记录当中并在之后将其合并到之前的修改中：
 
-```
+```sh
 git add --all
 git commit --amend
 ```
@@ -280,13 +280,13 @@ git commit --amend
 这一部分的操作需要更高的技能。Git 允许你对多次提交进行[修改](https://git-scm.com/docs/git-rebase)。换句话说：它允许你对历史的提交进行修改。
 
 
-```
+```sh
 git rebase --interactive @~6
 ```
 
 在命令结尾处的 `6` 表示的是想要进行修改的提交的编号。它会打开一个编辑器，其内容是之前6次的历史提交信息列表：
 
-```
+```sh
 pick 80d02a1 tpl: Add hasPrefix to the template funcs' "smoke test"
 pick aaee038 tpl: Sort the smoke tests
 pick f0dbf2c tpl: Add the other test case for hasPrefix
@@ -298,7 +298,7 @@ pick 3502f2e Refactoring and typo fixes
 在上面的例子中，我们应该将最后的提交到本文档之间的提交(`Add "How to contribute to Jenkins X" tutorial`)历史提交进行合并。你可以“压缩”提交， 如，将两个及以上的提交合并为一个。
 在提交信息之前，所有的操作都将会执行。替换 `pick` 为想要进行的操作。在这个例子当中我们使用 `squash` 或者其省略版 `s`。
 
-```
+```sh
 pick 80d02a1 tpl: Add hasPrefix to the template funcs' "smoke test"
 pick aaee038 tpl: Sort the smoke tests
 pick f0dbf2c tpl: Add the other test case for hasPrefix
@@ -311,7 +311,7 @@ squash 3502f2e Refactoring and typo fixes
 
 修改后，应该是类似如下的内容：
 
-```
+```sh
 pick 80d02a1 tpl: Add hasPrefix to the template funcs' "smoke test"
 pick aaee038 tpl: Sort the smoke tests
 pick f0dbf2c tpl: Add the other test case for hasPrefix
@@ -324,7 +324,7 @@ squash 3502f2e Refactoring and typo fixes
 
 再一次，将会打开新的窗口。输入新的提交信息并且保存。你的终端将会显示如下类似的状态信息：
 
-```
+```sh
 Successfully rebased and updated refs/heads/<BRANCHNAME>.
 ```
 
@@ -334,7 +334,7 @@ Successfully rebased and updated refs/heads/<BRANCHNAME>.
 
 我们需要指定目标地址以使得将我们的提交推送回到在Github中的分支版本库。目标地址由 `remote` 和 `branch`名称所构成。在之前的操作中，`remote` 地址与我们的GitHub账号所对应，以我为例是 `digitalcraftsman`。分支（branch）应该和我们本地的一样。 这就使得识别相应的分支变得简单。
 
-```
+```sh
 git push --set-upstream <YOUR-GITHUB-USERNAME> <BRANCHNAME>
 ```
 

--- a/content/zh/docs/contributing/code/triage.zh.md
+++ b/content/zh/docs/contributing/code/triage.zh.md
@@ -15,7 +15,7 @@ Jenkins X 项目主要的问题跟踪系统是 https://github.com/jenkins-x/jx/i
 当对问题进行分类时，来自 Jenkins X 团队的某个成员将分配标签用来描述问题的 __area__ 和 __kind__ 。有可能，他们还将增加一个 priority ，但是，在进一步分析或更广泛的可见性之后，这些 priority 可能会发生变化。
 
 标签通过 prow [label](https://prow.k8s.io/plugins) 插件使用 GitHub 评论被添加。例如：
-```
+```text
 /kind bug
 /area prow
 /priority important-soon

--- a/content/zh/docs/contributing/components/custom-resources.md
+++ b/content/zh/docs/contributing/components/custom-resources.md
@@ -12,7 +12,7 @@ Kubernetes 提供了一个叫做[自定义资源](https://kubernetes.io/docs/con
 
 Jenkins X 原生地支持[环境](/zh/docs/concepts/features/#environments)，允许为你们团队定义环境，并通过 [jx get environments](/commands/jx_get_environments) 查询：
 
-```shell
+```sh
 jx get environments
 ```
 
@@ -20,13 +20,13 @@ jx get environments
 
 因此，你还可以通过 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) 查询环境：
 
-```shell
+```sh
 kubectl get environments
 ```
 
 或者你想要通过 `YAML` 直接编辑它们的话：
 
-```shell
+```sh
 kubectl edit env staging
 ```
 

--- a/content/zh/docs/contributing/documentation/_index.md
+++ b/content/zh/docs/contributing/documentation/_index.md
@@ -10,7 +10,7 @@ description: 如何完善 Jenkins X 文档
 
 然后，你可以创建一个独立的分支。一定要选择符合内容类型的描述性分支名称。下面的一个示例分支的名称，你可以用于添加一个新的网站用于展示：
 
-```
+```sh
 git checkout -b jon-doe-showcase-addition
 ```
 
@@ -20,7 +20,7 @@ Jenkins X 文档重用 Jenkins X 的[骨架][archetypes]特点。在 Jenkins X �
 
 向 Jenkins X 中添加新的内容遵循下面相似的模式，不用考虑内容章节：
 
-```
+```sh
 hugo new <DOCS-SECTION>/<new-content-lowercase>.md
 ```
 
@@ -30,7 +30,7 @@ Jenkins X 文档中所有的页面，使用典型的三个反引号这样的语�
 
 你可选的语言是 `xml`/`html`, `go`/`golang`, `md`/`markdown`/`mkd`, `handlebars`, `apache`, `toml`, `yaml`, `json`, `css`, `asciidoc`, `ruby`, `powershell`/`ps`, `scss`, `sh`/`zsh`/`bash`/`git`, `http`/`https`, 和 `javascript`/`js`.
 
-```
+```html
 <h1>Hello world!</h1>
 ```
 
@@ -38,7 +38,7 @@ Jenkins X 文档中所有的页面，使用典型的三个反引号这样的语�
 
 块引用可以通过 [典型的 Markdown 块引用语法][bqsyntax] 添加到 Jenkins X 文档中：
 
-```
+```txt
 > Without the threat of punishment, there is no joy in flight.
 ```
 
@@ -48,7 +48,7 @@ Jenkins X 文档中所有的页面，使用典型的三个反引号这样的语�
 
 然而，你可以简单快速地添加一个 `<cite>` 元素（通过 JavaScript 在客户端添加），通过在连字符两边添加空格来区分你的块引用和参考。
 
-```
+```txt
 > Without the threat of punishment, there is no joy in flight. - [Kobo Abe](https://en.wikipedia.org/wiki/Kobo_Abe)
 ```
 

--- a/content/zh/docs/contributing/documentation/apidocs.md
+++ b/content/zh/docs/contributing/documentation/apidocs.md
@@ -21,8 +21,8 @@ resources](https://github.com/jenkins-x/jx/tree/master/pkg/apis/jenkins.io/v1) �
 自定义资源文档是由与 Kubernetes [同样的工具链](https://kubernetes.io/docs/contribute/generate-ref-docs/kubernetes-api/)而生成的，但是一系列的 `jx` 的命令将其包装了起来，因此你不需要下载以及配置这些不同的工具。
 
 HTML 文档是由 [OpenAPI 说明](https://github.com/jenkins-x/jx/tree/master/docs/apidocs/openapi-spec) 生成的，依次的由 [Go 结构体](https://github.com/jenkins-x/jx/tree/master/pkg/client/openapi) 生成，而这些结构体是由代码的注释生成的。想要生成结构体和 OpenAPI 说明执行命令：
- ```bash
- $ make generate-openapi
+ ```sh
+ make generate-openapi
  ```
 
  {{% alert %}}
@@ -31,7 +31,7 @@ HTML 文档是由 [OpenAPI 说明](https://github.com/jenkins-x/jx/tree/master/d
 
  生成 HTML 运行：
 
- ```bash
+ ```sh
  make generate-docs
  ```
 

--- a/content/zh/docs/getting-started/first-project/create-quickstart.md
+++ b/content/zh/docs/getting-started/first-project/create-quickstart.md
@@ -4,26 +4,26 @@ linktitle: 快速开始
 description: 如何创建快速开始应用并导入 Jenkins X
 ---
 
-你可以由预制的应用开始一个项目，而不是从头开始。 
+你可以由预制的应用开始一个项目，而不是从头开始。
 
 你可以通过命令 [jx create quickstart](/commands/jx_create_quickstart) ，从我们预制的快速应用列表中创建一个新的应用。
 
-```shell
-$ jx create quickstart
+```sh
+jx create quickstart
 ```
 
 然后，根据列表选择一个。
 
 如果你清楚列表中你所需要的语言，可以进行如下过滤：
 
-```shell
-$ jx create quickstart  -l go
+```sh
+jx create quickstart  -l go
 ```
 
 或者使用文本过滤器对项目名称做过滤：
 
-```shell
-$ jx create quickstart  -f http
+```sh
+jx create quickstart  -f http
 ```
 
 ### 当你选择快速开始时的细节
@@ -31,7 +31,7 @@ $ jx create quickstart  -f http
 一旦你选择项目并命名后，下面的步骤会自动完成：
 
 * 在子目录中创建应用
-* 把你的代码添加到 git 库中 
+* 把你的代码添加到 git 库中
 * 在 git 服务上添加远程库，例如： [GitHub](https://github.com)
 * 推送代码到远程库
 * 添加默认文件：
@@ -42,7 +42,7 @@ $ jx create quickstart  -f http
   * 在 Kubernetes 中通过 helm chart 运行你的应用
 * 为你的 Jenkins 在 git 远程库上注册 webhook
 * 为你的 Jenkins 添加 git 库
-* 首次触发流水线 
+* 首次触发流水线
 
 ### 快速开始的原理？
 
@@ -54,7 +54,7 @@ $ jx create quickstart  -f http
 
 例如：你可以通过下面命令查看支持的所有语言：
 
-```shell
+```sh
 ls -al ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs
 ```
 
@@ -65,7 +65,7 @@ ls -al ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs
   * `Dockerfile` 将程序打包为 docker 镜像
   * `Jenkinsfile` 使用申明式流水线（pipeline）实现持续构建、持续部署
   * Helm Charts 在 Kubernetes 上部署程序，并且实现 [预发环境](/docs/concepts/features/#preview-environments)
-   
+
 ## 添加你自己的快速开始
 
 如果你想要提交一个新的快速开始给 Jenkins X，请把你 GitHub中的链接[提交问题](https://github.com/jenkins-x/jx/issues/new?labels=quickstart&title=Add%20quickstart&body=Please%20add%20this%20github%20quickstart:) 到[快速开始组织](https://github.com/jenkins-x-quickstarts)，然后它就会出现在菜单 `jx create quickstart` 中。
@@ -74,8 +74,8 @@ ls -al ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs
 
 在我们完成这些事情之前，你还是可以在命令 `jx create quickstart` 中通过参数 `-g` or `--organisations` 来实现。
 
-```shell
-$ jx create quickstart  -l go --organisations my-github-org
+```sh
+jx create quickstart  -l go --organisations my-github-org
 ```
 
 在 `my-github-org`中可以找到所有 Jenkins X 需要的快速开始。

--- a/content/zh/docs/getting-started/setup/create-cluster.md
+++ b/content/zh/docs/getting-started/setup/create-cluster.md
@@ -1,16 +1,16 @@
 ---
 title: 创建新集群
 linktitle: 创建新集群
-description: 如何通过 Jenkins X 创建新的 Kubernetes 集群 
+description: 如何通过 Jenkins X 创建新的 Kubernetes 集群
 date: 2018-04-21
 publishdate: 2018-04-21
 categories: [getting started]
 keywords: [install]
 ---
 
-                
+
 通过已经安装的 Jenkins X 创建一个新的集群，使用命令  [jx create cluster](/commands/jx_create_cluster) 。
-    
+
 如下所示，支持很多不同的公有云提供商。
 
 __为了最好的入门体验，我们目前推荐使用 Google Container Engine (GKE)__。如果你没有谷歌云账号的话，谷歌云平台提供三百美元的额度。查看 https://console.cloud.google.com/freetrial
@@ -22,19 +22,21 @@ __为了最好的入门体验，我们目前推荐使用 Google Container Engine
 
 ### 使用谷歌云 (GKE)
 
-使用命令 [jx create cluster gke](/commands/jx_create_cluster_gke) ： 
+使用命令 [jx create cluster gke](/commands/jx_create_cluster_gke) ：
 
     jx create cluster gke
 
 该命令假设你有一个谷歌账户，并且已经设置了一个默认项目，可以再里面创建 Kubernetes 集群。
-     
+
 现在 **[使用 Jenkins X 更快速地开发应用](/zh/docs/getting-started/next/)**。
-       
+
 ### 使用亚马逊 (AWS)
 
-使用命令 [jx create cluster aws](/commands/x_create_cluster_aws) ： 
+使用命令 [jx create cluster aws](/commands/x_create_cluster_aws) ：
 
-    jx create cluster aws
+```sh
+jx create cluster aws
+```
 
 这会通过你的亚马逊账户，使用命令 [kops](https://github.com/kubernetes/kops) 创建一个新的 Kubernetes 集群并安装 Jenkins X。
 
@@ -42,7 +44,7 @@ __为了最好的入门体验，我们目前推荐使用 Google Container Engine
 
 然后，在 Cloud9 中打开一个新的终端，试试这些命令：
 
-```shell 
+```sh
 curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Site.Params.release}}/jx-linux-amd64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 jx create cluster aws
@@ -50,17 +52,19 @@ jx create cluster aws
 
 现在 **[使用 Jenkins X 更快速地开发应用](/zh/docs/getting-started/next/)**。
 
-        
+
 ### 使用 Azure (AKS)
 
-使用命令 [jx create cluster aks](/commands/jx_create_cluster_aks) ： 
+使用命令 [jx create cluster aks](/commands/jx_create_cluster_aks) ：
 
-    jx create cluster aks
-    
+```sh
+jx create cluster aks
+```
+
 现在 **[使用 Jenkins X 更快速地开发应用](/zh/docs/getting-started/next/)**。
-    
-### 使用 Minikube (local)    
-    
+
+### 使用 Minikube (local)
+
 有些人在开始使用 minikube 时遇到问题，可能有几个原因：
 
 * minikube 需要更新你的机器以及虚拟化软件
@@ -70,7 +74,9 @@ jx create cluster aws
 
 如果你还是想尝试 minikube，那么，我们建议从头开始，并让 jx 帮你创建
 
-    jx create cluster minikube
+```sh
+jx create cluster minikube
+```
 
 现在 **[使用 Jenkins X 更快速地开发应用](/zh/docs/getting-started/next/)**。
 

--- a/content/zh/docs/getting-started/setup/install.md
+++ b/content/zh/docs/getting-started/setup/install.md
@@ -15,21 +15,21 @@ keywords: [install]
 
 在 Mac 上你可以使用 [brew](https://brew.sh/)：
 
-```shell
+```sh
 brew tap jenkins-x/jx
-brew install jx 
+brew install jx
 ```
 
 或者，如果您尚未安装 [brew](https://brew.sh/) ，并且喜欢手动安装的话，请执行如下指令安装:
 
-```shell
-curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Site.Params.release}}/jx-darwin-amd64.tar.gz | tar xzv 
+```sh
+curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Site.Params.release}}/jx-darwin-amd64.tar.gz | tar xzv
 sudo mv jx /usr/local/bin
 ```
 
 ### Linux
 
-```shell
+```sh
 mkdir -p ~/.jx/bin
 curl -L https://github.com/jenkins-x/jx/releases/download/v{{.Site.Params.release}}/jx-linux-amd64.tar.gz | tar xzv -C ~/.jx/bin
 export PATH=$PATH:~/.jx/bin
@@ -42,32 +42,32 @@ echo 'export PATH=$PATH:~/.jx/bin' >> ~/.bashrc
 
   要安装 `jx` 二进制请运行：
 
-  ```cmd
-  choco install jenkins-x
-  ```
+```sh
+choco install jenkins-x
+```
 
   要升级 `jx` 二进制请运行：
 
-  ```cmd
-  choco upgrade jenkins-x
-  ```
+```sh
+choco upgrade jenkins-x
+```
 
 - 如果你使用 [scoop](https://scoop.sh)，那么这里有一个 [可用的清单](https://github.com/lukesampson/scoop/blob/master/bucket/jx.json)。
 
   要安装 `jx` 二进制请运行：
 
-  ```cmd
-  scoop install jx
-  ```
+```sh
+scoop install jx
+```
 
   要升级 `jx` 二进制请运行：
 
-  ```cmd
-  scoop update jx
-  ```
-    
+```sh
+scoop update jx
+```
+
 ### 其他平台
-    
+
 [下载二进制包](https://github.com/jenkins-x/jx/releases) `jx` 然后加到环境变量 `$PATH` 中
 
 或者，你可以尝试 [自行构建](https://github.com/jenkins-x/jx/blob/master/docs/contributing/hacking.md)。然而，如果你要自行构建的话，请注意移除所有旧版本的 `jx` 二进制文件，这样你的本地构建才会出现在环境变量 `$PATH` 的第一位 :)
@@ -76,10 +76,14 @@ echo 'export PATH=$PATH:~/.jx/bin' >> ~/.bashrc
 
 查找可用的命令类型：
 
-    jx
+```sh
+jx
+```
 
 或者，获取指定命令的帮助，例如： `create` 命令，可以输入：
 
-    jx help create
+```sh
+jx help create
+```
 
 你也可以浏览 [jx 命令参考文档](/commands/jx)

--- a/content/zh/docs/managing-jx/common-tasks/build-packs.md
+++ b/content/zh/docs/managing-jx/common-tasks/build-packs.md
@@ -47,7 +47,7 @@ pipeline {
           container('foo') {
             sh "foo deploy"
           }
-```          
+```
 
 一旦你的 `Jenkinsfile` 可以在你的示例工程为你的语言实现 CI/CD 的话，我们因该把 `Dockerfile`, `Jenkinsfile` 和 charts 文件夹拷贝到你的派生 [jenkins-x/draft-packs 仓库](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes) 中。
 
@@ -55,15 +55,15 @@ pipeline {
 
 例如：
 
-```shell 
+```sh
 export PACK="foo"
 mkdir ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/$PACK
 cp Dockerfile Jenkinsfile  ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/$PACK
 
 # the charts will be in some folder charts/somefoo
 cp -r charts/somefoo ~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/$PACK/charts
-```   
+```
 
 当你的构建包在 `~/.jx/draft/packs/github.com/jenkins-x/draft-packs/packs/` 文件夹中，就可以通过命令 [jx import](/commands/jx_import) 来导入工程，使用编程语言来检测并查找最合适的构建包。如果你的构建包自定义检测逻辑的话，请让我们指导，我们可以帮助改进 [jx import](/commands/jx_import) 使得在你的构建包上做的更好。例如：我们有一些自定义逻辑更好地处理 [maven 和 Gradle](https://github.com/jenkins-x/jx/blob/master/pkg/jx/cmd/import.go#L383-L397)。
-          
+
 如果你需要任何帮助 [请加入社区](/zh/community/) 。

--- a/content/zh/docs/managing-jx/common-tasks/config.md
+++ b/content/zh/docs/managing-jx/common-tasks/config.md
@@ -41,12 +41,12 @@ chartmuseumServiceLink:
 
 ## Jenkins 镜像
 
-Jenkins X 中我们提供了一个默认的 Jenkins docker 镜像 [jenkinsxio/jenkinsx](https://hub.docker.com/r/jenkinsxio/jenkinsx/)，把我们所需要的所有插件包含在里面。 
+Jenkins X 中我们提供了一个默认的 Jenkins docker 镜像 [jenkinsxio/jenkinsx](https://hub.docker.com/r/jenkinsxio/jenkinsx/)，把我们所需要的所有插件包含在里面。
 
-如果你想添加自己的插件，你可以使用我们的基础镜像创建一个你自己的 Dockerfile 和镜像，如下所示： 
+如果你想添加自己的插件，你可以使用我们的基础镜像创建一个你自己的 Dockerfile 和镜像，如下所示：
 
-```
-# Dockerfile for adding plugins to Jenkins X 
+```dockerfile
+# Dockerfile for adding plugins to Jenkins X
 FROM jenkinsxio/jenkinsx:latest
 
 COPY plugins.txt /usr/share/jenkins/ref/openshift-plugins.txt
@@ -54,15 +54,15 @@ RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/openshift-plugins
 ```
 然后以下面的形式将你所有自定义插件放到 `plugins.txt`：
 
-``` 
+```text
 myplugin:1.2.3
 anotherplugin:4.5.6
 ```
 
 一旦你通过 CI/CD 构建和发布了你的镜像，你就可以在安装 Jenkins X 时使用它：
 
-为了用你自定义的镜像配置 Jenkins X ，你可以在 `myvalues.yaml` 文件中指定你的 Jenkins 镜像：  
-  
+为了用你自定义的镜像配置 Jenkins X ，你可以在 `myvalues.yaml` 文件中指定你的 Jenkins 镜像：
+
 ```yaml
 jenkins:
   Master:
@@ -74,14 +74,14 @@ jenkins:
 
 ## Docker Registry
 
-We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS. 
+We try and use the best defaults for each platform for the Docker Registry; e.g. using ECR on AWS.
 
 然而，你也可以在执行命令 [jx create cluster](/commands/jx_create_cluster) 或 [jx install](/commands/jx_install) 时，通过选项 `--docker-registry` 来指定。
 
 例如：
 
-``` 
+```sh
 jx create cluster gke --docker-registry eu.gcr.io
-```   
+```
 
 但是，如果你使用了不同的 Docker Registry 的话，你可能需要[修改 secret 才能连接到 docker](/docs/managing-jx/common-tasks/docker-registry/#update-the-config-json-secret)。

--- a/content/zh/docs/managing-jx/common-tasks/create-custom-builder.md
+++ b/content/zh/docs/managing-jx/common-tasks/create-custom-builder.md
@@ -16,7 +16,7 @@ keywords: [install,builder]
 
 首先，您需要为 Builder 创建一个 docker 镜像。从 `Dockerfile` 开始的一个实例可能类似于：
 
-```
+```dockerfile
 FROM jenkinsxio/builder-base:latest
 
 # Install your tools and libraries
@@ -27,15 +27,15 @@ CMD ["gcc"]
 
 现在，您可以构建并发布这个镜像到您的 registry：
 
-```shell
-export BUILDER_IMAGE=<YOUR_REGISTRY>/<YOUR_BUILDER_IMAGE>:<VERSION> 
+```sh
+export BUILDER_IMAGE=<YOUR_REGISTRY>/<YOUR_BUILDER_IMAGE>:<VERSION>
 docker build -t ${BUILDER_IMAGE} .
-docker push ${BUILDER_IMAGE} 
+docker push ${BUILDER_IMAGE}
 ```
 
 别担心，当新的镜像需要构建时，您无需每次手动执行这些步骤。Jenkins X 可以为您管理这些。您只需要把 `Dockerfile` 推送到类似于[这个](https://github.com/jenkins-x/builder-go)代码仓库中。然后，根据您的组织名称来调整 `Jenkinsfile` ，并使用下面的命令导入 Jenkins X 平台：
 
-```
+```sh
 jx import --url <REPOSITORY_URL>
 ```
 
@@ -74,7 +74,7 @@ jenkins:
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
           Dlang:
-            Image: <YOUR_BUILDER_IMAGE> 
+            Image: <YOUR_BUILDER_IMAGE>
             Privileged: true
             RequestCpu: "400m"
             RequestMemory: "512Mi"
@@ -126,7 +126,7 @@ Jenkins X 自带了很多[预安装的 Builder](https://raw.githubusercontent.co
 
 然后，您可以在目录 `~/.jx/` 中创建文件 `myvalues.yaml` ，并写入一下内容：
 
-```
+```yaml
 jenkins:
   Agent:
     PodTemplates:

--- a/content/zh/docs/managing-jx/common-tasks/docker-registry.md
+++ b/content/zh/docs/managing-jx/common-tasks/docker-registry.md
@@ -14,15 +14,15 @@ description: 配置你的 docker registry
 
 为了指定 Docker Registry 的主机、端口，你可以使用 Jenkins 控制台：
 
-```
+```sh
 jx console
-``` 
+```
 
 然后，定位到 `管理 Jenkins -> 系统配置`，并修改环境变量 `DOCKER_REGISTRY` 指向你选择的 Docker Registry。
 
 另一种方法是，把下面的内容添加到你的自定义 Jenkins X 平台 helm charts 的`values.yaml` 文件中：
 
-```yaml 
+```yaml
 jenkins:
   Servers:
     Global:
@@ -58,16 +58,16 @@ jenkins:
 
 然后需要更新凭据 `jenkins-docker-cfg` ，你可以执行以下操作:
 
-```
+```sh
 kubectl delete secret jenkins-docker-cfg
 kubectl create secret generic jenkins-docker-cfg --from-file=./config.json
-```   
+```
 
 ## 使用 Docker Hub
 
 如果你想要发布你的镜像到 Docker Hub 当中 ，则需要修改你的 `config.json` 像下面那样:
 
-```json 
+```json
 {
     "auths": {
         "https://index.docker.io/v1/": {
@@ -76,7 +76,7 @@ kubectl create secret generic jenkins-docker-cfg --from-file=./config.json
         }
     }
 }
-``` 
+```
 
 ### 为你的 registry 挂载凭证
 

--- a/content/zh/docs/managing-jx/common-tasks/git.md
+++ b/content/zh/docs/managing-jx/common-tasks/git.md
@@ -1,25 +1,25 @@
 ---
 title: Git 服务器
 linktitle: Git 服务器
-description: 使用不同的 Git 服务器 
+description: 使用不同的 Git 服务器
 ---
 
 
 Jenkins X 默认使用 [GitHub](https://github.com/)，用于开源项目的免费公共 git 托管方案。
- 
+
 然而，在企业中工作时，你可能希望使用不同的 git 服务器。
 
 你可以通过 [jx get git](/commands/jx_get_git) 列出配置好的 git 服务器。
 
-```
+```sh
 jx get git
 ```
 
 ## 添加一个新的 git 服务商
 
 如果你在某个地方已经有了一个 git 服务，你可以通过 [jx create git server](/commands/jx_create_git_server) 把它添加到 Jenkins X中：
-                                    
-``` 
+
+```sh
 jx create git server gitKind someURL
 ```
 
@@ -29,7 +29,7 @@ jx create git server gitKind someURL
 
 要添加一个企业 GitHub 服务，尝试：
 
-``` 
+```sh
 jx create git server github https://github.foo.com -n GHE
 ```
 
@@ -39,7 +39,7 @@ jx create git server github https://github.foo.com -n GHE
 
 要添加 BitBucket ，尝试：
 
-```
+```sh
 jx create git server bitbucket -n BitBucket https://bitbucket.org
 ```
 
@@ -47,7 +47,7 @@ jx create git server bitbucket -n BitBucket https://bitbucket.org
 
 为了添加一个 git 服务，你需要通过 [jx create git token](/commands/jx_create_git_token) 添加一个用户名和 API token：
 
-``` 
+```sh
 jx create git token -n myProviderName myUserName
 ```
 
@@ -61,17 +61,17 @@ jx create git token -n myProviderName myUserName
 
 要在 Jenkins X 中使用 [gitea](https://gitea.io/en-us/)，你需要在安装 Jenkins X 之前启用 `gitea` 插件：
 
-``` 
+```sh
 jx edit addon gitea -e true
-``` 
+```
 
 你可以通过 [jx get addons](/commands/jx_get_addons) 查看启用的插件：
 
-``` 
+```sh
 jx get addons
-``` 
+```
 
-现在，当你 [安装 Jenkins X](/zh/docs/getting-started/) 时，也会安装 `gitea` 插件。 
+现在，当你 [安装 Jenkins X](/zh/docs/getting-started/) 时，也会安装 `gitea` 插件。
 
 无论什么时候，Jenkins X 需要为一个环境或者新项目创建一个 git 库时，gitea 服务都会出现在选择列表中。
 

--- a/content/zh/docs/managing-jx/common-tasks/install-on-cluster.md
+++ b/content/zh/docs/managing-jx/common-tasks/install-on-cluster.md
@@ -20,25 +20,25 @@ Jenkins X 可以在 Kubernetes 1.8 以及更高版本上安装。需要的依赖
 
 如果你是通过 [kops](https://github.com/kubernetes/kops) 创建的 kubernetes 集群，那么你可以这么做：
 
-```
-kops edit cluster 
+```sh
+kops edit cluster
 ```
 
 然后，确保在 YAML 文件的章节 `spec` 中有 `docker` 配置：
 
-```yaml 
+```yaml
 ...
 spec:
   docker:
     insecureRegistry: 100.64.0.0/10
     logDriver: ""
-``` 
+```
 
 上面的 IP 范围 `100.64.0.0/10` 是 AWS 上的，但你需要修改为其他 Kubernetes 集群的；它依赖于 Kubernetes 服务的 IP 范围。
- 
+
 保存后，你可以参考下面的命令进行验证：
 
-```
+```sh
 kops get cluster -oyaml
 ```
 
@@ -46,7 +46,7 @@ kops get cluster -oyaml
 
 现在，确保这些修改在你的集群类型上是激活的：
 
-```
+```sh
 kops update cluster --yes
 kops rolling-update cluster --yes
 ```

--- a/content/zh/docs/managing-jx/common-tasks/manage-via-gitops.md
+++ b/content/zh/docs/managing-jx/common-tasks/manage-via-gitops.md
@@ -13,7 +13,7 @@ keywords: [install,kubernetes]
 
 当前这仅在 AWS 和 Google 云可用，因为它要求我们的 vault 操作员（需要云存储和 KMS ）存储凭据，而所有其他配置都存储在开发环境 git 仓库中。
 
-## 使用 GitOps 管理 Jenkins X 
+## 使用 GitOps 管理 Jenkins X
 
 如果你正在创建一个集群或者在已经存在的集群安装，这里有一种快速简便的方法来使用 GitOps 来管理 Jenkins X 本身。它是 `—ng` ，为下一代 Jenkins X 而来。在我们今年晚些时候发布 Jenkins X 2.x 时，我们会将此功能标记设为默认选项。
 
@@ -31,8 +31,8 @@ keywords: [install,kubernetes]
 
 如果你在升级 Jenkins X 过程中遇到任何问题，这里有一种手动方法可以应用开发环境的 git 存储库的内容：
 
-``` 
+```sh
 git clone $MY_DEV_GIT_CLONE_URL jenkins-x-dev-env
 cd jenkins-x-dev-env/env
-jx step env apply 
+jx step env apply
 ```

--- a/content/zh/docs/managing-jx/common-tasks/pod-templates.md
+++ b/content/zh/docs/managing-jx/common-tasks/pod-templates.md
@@ -41,7 +41,7 @@ pipeline {
           }
           ...
 ```
- 
+
 ## 提交新的 Pod 模板
 
 如果你正在使用一个新的 [build pack](/zh/architecture/build-packs)，那么，我们欢迎你 [提交](/zh/docs/contributing/) 一个新的 pod 模板，而且我们可以把它包含在 Jenkins X 的发行版中！
@@ -79,7 +79,7 @@ pipeline {
 
 现在，添加新的 Pod 模板最简单的方式就是通过 Jenkins 控制台。例如：
 
-```bash 
+```sh
 jx console
 ```
 

--- a/content/zh/docs/managing-jx/issues.md
+++ b/content/zh/docs/managing-jx/issues.md
@@ -33,7 +33,7 @@ description: Issues using Jenkins X 常见问题的解决方案。
 
 如果你在 Mac 上通过 hyperkit 使用 minikube，并发现 minikube 启动失败的日志如下：
 
-```
+```sh
 Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
 Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
 Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
@@ -44,7 +44,7 @@ Temporary Error: Could not find an IP address for 46:0:41:86:41:6e
 
 解决的办法是请尝试下面的操作：
 
-```
+```sh
 rm ~/.minikube/machines/minikube/hyperkit.pid
 ```
 
@@ -71,7 +71,7 @@ expose:
 
 因此，如果你输入：
 
-```
+```sh
 jx open
 ```
 

--- a/content/zh/docs/using-jx/common-tasks/browsing.md
+++ b/content/zh/docs/using-jx/common-tasks/browsing.md
@@ -4,20 +4,20 @@ linktitle: 浏览
 description: 浏览 Jenkins X 中的资源
 ---
 
-                
+
 如果你之前用过 Kubernetes，你可能使用过 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) 命令查看 Kubernetes 资源：
 
-```shell
+```sh
 kubectl get pods
 ```
 
 Jenkins X 的命令行工具，[jx](/commands/jx)，和 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) 看起来相似，并且可以让你看到所有的 Jenkins X 资源。
 
 ### 查看 Jenkins 控制台
- 
+
 如果你熟悉 Jenkins 控制台，那么你可以使用 [jx console](/commands/jx_console) ：
 
-```shell
+```sh
 jx console
 ```
 
@@ -27,7 +27,7 @@ jx console
 
 要查看当前流水线使用 [jx get pipelines](/commands/jx_get_pipelines):
 
-```shell
+```sh
 jx get pipelines
 ```
 
@@ -35,7 +35,7 @@ jx get pipelines
 
 通过 [jx get build logs](/commands/jx_get_build_logs) 查看当前流水线构建日志：
 
-```shell
+```sh
 jx get build logs
 ```
 
@@ -43,13 +43,13 @@ jx get build logs
 
 你可以通过下面快速过滤
 
-```shell
+```sh
 jx get build logs -f myapp
 ```
 
 或者，你希望指定
 
-```shell
+```sh
 jx get build logs myorg/myapp/master
 ```
 
@@ -57,13 +57,13 @@ jx get build logs myorg/myapp/master
 
 为了查看当前流水线的活动 [jx get activities](/commands/jx_get_activities)：
 
-```shell
+```sh
 jx get activities
 ```
 
 如果你想要观察你的应用 `myapp`，你可以使用：
 
-```shell
+```sh
 jx get activities -f myapp -w
 ```
 
@@ -74,25 +74,25 @@ jx get activities -f myapp -w
 为了查看你的团队所有环境的所有应用的URL和 pod 数量，使用 [jx get applications](/commands/applications)：
 
 
-```shell
+```sh
 jx get applications
 ```
 
 如果你想要隐藏 URL 或者 pod 数量，你可以使用 `u` 或 `-p`。例如：为了隐藏 URL：
 
-```shell
+```sh
 jx get applications -u
 ```
 
 或者隐藏 pod 数量：
 
-```shell
+```sh
 jx get applications -p
 ```
 
 你还可以根据环境来过滤应用：
 
-```shell
+```sh
 jx get applications -e staging
 ```
 
@@ -102,7 +102,7 @@ jx get applications -e staging
 
 为了查看你们团队中的 [环境](/zh/docs/concepts/features/#environments)，使用 [jx get environments](/commands/jx_get_environments)：
 
-```shell
+```sh
 jx get environments
 ```
 

--- a/content/zh/docs/using-jx/common-tasks/create-spring.md
+++ b/content/zh/docs/using-jx/common-tasks/create-spring.md
@@ -4,15 +4,15 @@ linktitle: 创建 Spring Boot
 description: 如何创建Spring Boot应用并导入Jenkins X
 ---
 
-                
+
 如果你在开发基于Java的微服务，那么，你可能正在用流行的[Spring Boot](https://projects.spring.io/spring-boot/)。
 
 你可以利用[Spring Boot Initializr](http://start.spring.io/)创建Spring Boot应用，然后通过执行命令 [jx import](/commands/jx_import) 来[导入Jenkins X](/developing/import)。
- 
+
 然而，另外一个快速自动化的方式，是通过执行 [jx create spring](/commands/jx_create_spring) 命令实现：
 
-```shell
-$ jx create spring -d web -d actuator
+```sh
+jx create spring -d web -d actuator
 ```
 
 参数 `-d` 允许你指定希望添加到 Spring Boot 应用中的依赖。
@@ -31,5 +31,5 @@ $ jx create spring -d web -d actuator
   * 在 Kubernetes 中通过 helm chart 运行你的应用
 * 为你的 Jenkins 在 git 远程库上注册 webhook
 * 为你的 Jenkins 添加 git 库
-* 首次触发流水线 
+* 首次触发流水线
 

--- a/content/zh/docs/using-jx/common-tasks/import.md
+++ b/content/zh/docs/using-jx/common-tasks/import.md
@@ -4,12 +4,12 @@ linktitle: 导入
 description: 如何把已经存在的项目导入 Jenkins X
 ---
 
-                
+
 如果你已经有一些源码，希望导入 Jenkins X，你可以使用 [jx import](/commands/jx_import) 命令。
 
-```shell
-$ cd my-cool-app
-$ jx import
+```sh
+cd my-cool-app
+jx import
 ```
 
 导入将会执行下面的动作（提示你按照这个方法来）：
@@ -33,29 +33,29 @@ $ jx import
 
 如果你希望导入的工程已经在 git 远程库中，那么，你可以使用参数 `--url`：
 
-```shell
-    jx import --url https://github.com/jenkins-x/spring-boot-web-example.git
+```sh
+jx import --url https://github.com/jenkins-x/spring-boot-web-example.git
 ```
 
 ### 导入 GitHub 项目
 
 如果你希望从 GitHub 组织中导入，可以使用：
- 
-```shell
-    jx import --github --org myname
+
+```sh
+jx import --github --org myname
 ```
 
 将会提示你需要导入的库。使用光标和空格键来选择（取消）要导入的库。
 
 如果你希望默认导入所有的库（那么反选你不想要的）添加 `--all`：
-   
-```shell
-    jx import --github --org myname --all
+
+```sh
+jx import --github --org myname --all
 ```
 
 为了过滤列表，你可以添加参数 `--filter`
 
-```shell
-    jx import --github --org myname --all --filter foo
-```  
-  
+```sh
+jx import --github --org myname --all --filter foo
+```
+

--- a/content/zh/docs/using-jx/common-tasks/issues.md
+++ b/content/zh/docs/using-jx/common-tasks/issues.md
@@ -1,15 +1,15 @@
 ---
 title: 问题
 linktitle: 问题
-description: 问题处理 
+description: 问题处理
 ---
 
 
-Jenkins X 默认使用你的 git 提供商中的问题跟踪系统来创建和浏览问题。 
+Jenkins X 默认使用你的 git 提供商中的问题跟踪系统来创建和浏览问题。
 
 例如：如果你在 GitHub 项目中的源码中，那么你可以输入 [jx create issue](/commands/jx_create_issue)：
 
-```
+```sh
 jx create issue -t "lets make things more awesome"
 ```
 
@@ -17,47 +17,47 @@ jx create issue -t "lets make things more awesome"
 
 你可以在你的项目上通过 [jx get issues](/commands/jx_get_issues) 列出打开的问题：
 
-```
+```sh
 jx get issues
 ```
-             
+
 ### 使用不同的问题跟踪
 
 如果你希望在项目中使用 JIRA，你首先需要添加一个 JIRA 服务。
 
 你可以通过 [jx create tracker server](/commands/jx_create_tracker_server) 注册你的 JIRA服务：
 
-```
+```sh
 jx create tracker server jira https://mycompany.atlassian.net/
 ```
 
 然后，你就可以通过 [jx get tracker](/commands/jx_get_tracker) 来查看你的问题追踪了：
 
-```
+```sh
 jx get tracker
 ```
-             
+
 然后，通过下面添加一个用户和 token：
 
-```
+```sh
 jx create tracker token -n jira  myEmailAddress
 ```
-      
+
 ### 配置项目的问题跟踪
 
 在你项目的源码中使用 [jx edit config](/commands/jx_edit_config):
 
-```
+```sh
 jx edit config -k issues
-```  
-           
-然后 
+```
+
+然后
 
 * 如果你有多个问题跟踪系统，选择一个用于当前项目
 * 在问题跟踪系统中输入项目名称（例如：大写的 JIRA 项目名称）
 
 在你的项目中一个叫做 `jenkins-x.xml` 的文件会被修改，这个文件应该被加到你的 git 库中。
- 
+
 
 
 

--- a/content/zh/docs/using-jx/common-tasks/kube-context.md
+++ b/content/zh/docs/using-jx/common-tasks/kube-context.md
@@ -1,15 +1,15 @@
 ---
-title: Kubernetes 上下文 
+title: Kubernetes 上下文
 linktitle: Kubernetes 上下文
-description: 处理 Kubernetes 上下文 
+description: 处理 Kubernetes 上下文
 ---
 
-                
+
 Kubernetes 命令行工具 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) 通过本地文件 `~/.kube/config`（会在 `$KUBECONFIG` 的文件） 记录你使用的 Kubernetes 集群和命名空间。
 
 如果你想要改变命名空间，你可以使用 kubectl 命令行：
 
-```shell
+```sh
 kubectl config set-context`kubectl config current-context` --namespace=foo
 ```
 
@@ -19,15 +19,15 @@ kubectl config set-context`kubectl config current-context` --namespace=foo
 
 使用 [jx environment](/commands/jx_environment) 来切换 [环境](/zh/docs/concepts/features/#environments)
 
-```shell
+```sh
 jx environment
 ```
 
 你将会看到当前团队的环境列表。使用方向键和回车来选择你想要切换的环境。或者按下 `Ctrl+C` 终止，不切换环境。
 
 或者，如果你知道想要切换的环境，可以直接把它作为参数：
- 
-```shell
+
+```sh
 jx env staging
 ```
 
@@ -36,15 +36,15 @@ jx env staging
 使用 [jx namespace](/commands/jx_namespace) 在 Kubernetes 不同的命名空间之间进行切换。
 
 
-```shell
+```sh
 jx namespace
 ```
 
 你会看到 Kubernetes 集群中所有命名空间的列表。使用方向键和回车选择你想要切换的。或者，按下 `Ctrl+C` 中断，不切换命名空间。
 
 或者，如果你知道想要切换的 Kubernetes 命名空间，可以直接把它作为参数：
- 
-```shell
+
+```sh
 jx ns jx-production
 ```
 
@@ -52,15 +52,15 @@ jx ns jx-production
 
 使用 [jx context](/commands/jx_context) 在不同的 Kubernetes 集群（或者上下文）之间切换。
 
-```shell
+```sh
 jx context
 ```
 
 你会得到当前机器上所有上下文的列表。使用方向键或者回车选择你想要切换的。或者，按下 `Ctrl+C` 中断，不切换集群。
 
 或者，如果你知道想要切换的 Kubernetes 集群，可以直接把它作为参数：
- 
-```shell
+
+```sh
 jx ctx gke_jenkinsx-dev_europe-west2-a_myuserid-foo
 jx ctx minikube
 ```
@@ -70,11 +70,11 @@ jx ctx minikube
 当前你通过 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) 切换 Kubernetes 的命名空间或上下文，或上面提到的命令，那么 Kubernetes 会把 **你所有的终端** 都进行切换，因为它更新的是共享文件 (`~/.kube/config` 或 `$KUBECONFIG`)。
 
 这样很方便——但有时候会有危险。例如：如果你想要在生产集群上做一些事情；但是，忘记了，然后在另外一个终端上执行命令要删除你的开发命名空间上所有的 pod——但是你忘记来刚刚切换到来生产命名空间上！
- 
+
 因此，如果通过一个 shell 命令来切换 Kubernetes 上下文或命名空间，有时候是很有帮助的。例如：如果你总是想要看一下集群中的生产环境，就只在那个 shell 中使用那个集群，这样可以减少事故。
- 
+
 你可以使用命令 [jx shell](/commands/jx_shell) 提示你选择不同的 Kubernetes 上下文，例如：[jx context](/commands/jx_context) 命令。然而，这样切换命名空间或集群就只能在当前 shell 中有效！
- 
+
 还有 [jx shell](/commands/jx_shell) 通过 [jx prompt](/commands/jx_prompt) 自动更新你的命令提示符，这样使得你的 shell 很清楚上下文或命名空间的修改。
 
 ### 定制你的 shell

--- a/content/zh/docs/using-jx/common-tasks/promote.md
+++ b/content/zh/docs/using-jx/common-tasks/promote.md
@@ -10,7 +10,7 @@ Jenkins X 的升级策略配置为 `Auto` 时，持续部署流水线通过配�
 
 要手动升级应用的一个版本到特定环境上，可以使用命令 [jx promote](/commands/jx_promote)。
 
-```shell 
+```sh
 jx promote myapp --version 1.2.3 --env production
 ```
 
@@ -19,7 +19,7 @@ jx promote myapp --version 1.2.3 --env production
 例如：等待5小时
 
 
-```shell 
+```sh
 jx promote myapp --version 1.2.3 --env production --timeout 5h
 ```
 

--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -10,3 +10,4 @@
 <link href="{{ $css.RelPermalink }}" rel="stylesheet" integrity="{{ $css.Data.integrity }}">
 {{ end }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/default.min.css">

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -2,6 +2,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
 {{ $jsBase := resources.Get "js/base.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $js := (slice $jsBase $jsAnchor) | resources.Concat "js/main.js" }}
@@ -20,4 +21,5 @@
     debug: false
   });
 </script>
+<script>hljs.initHighlightingOnLoad();</script>
 {{ partial "hooks/body-end.html" . }}


### PR DESCRIPTION
also updated and corrected a bunch of fence definitions.

I've removed most `$` in front of one-line commands, but left them in where the example includes the output of the command, to show which is the command and which is the output

fixes #2035 