### PR TITLE
fix: deadlink fix.

### DIFF
--- a/content/en/docs/contributing/documentation/apidocs.md
+++ b/content/en/docs/contributing/documentation/apidocs.md
@@ -10,7 +10,7 @@ Both types are generated from the `codegen` binary which is part of the jx [repo
 
 ## Setup your development environment
 
-It's best to make changes to the Jenkins X code on your local machine. Follow the [development](../development) guide
+It's best to make changes to the Jenkins X code on your local machine. Follow the [development](../../development) guide
 to get set up.
 
 ## Writing custom resource documentation


### PR DESCRIPTION
Page that generate error appear at the URL
https://jenkins-x.io/docs/contributing/documentation/apidocs/
(markdown content/en/docs/contributing/documentation/apidocs.md)