### PR TITLE
fix: correct link error in issue #2129

### DIFF
--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 Jenkins X is designed to make it simple for developers to work to DevOps principles and best practices. The approaches taken
-are based on the comprehensive research done for the book [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). You can read why we use [Accelerate](../accelerate) for the principals behind Jenkins X.
+are based on the comprehensive research done for the book [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). You can read why we use [Accelerate](../overview/accelerate) for the principals behind Jenkins X.
 
 
 ## Principles

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 Jenkins X is designed to make it simple for developers to work to DevOps principles and best practices. The approaches taken
-are based on the comprehensive research done for the book [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). You can read why we use [Accelerate](../overview/accelerate) for the principals behind Jenkins X.
+are based on the comprehensive research done for the book [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). You can read why we use [Accelerate](../overview/accelerate) for the principles behind Jenkins X.
 
 
 ## Principles


### PR DESCRIPTION
Link was pointed to a route that didn't exist. "https://jenkins-x.io/docs/overview/accelerate/" is correct route.