### PR TITLE
docs: found new video links, removed unrecorded talks

### DIFF
--- a/content/en/docs/getting-started/demos-talks-posts/talks.md
+++ b/content/en/docs/getting-started/demos-talks-posts/talks.md
@@ -1,182 +1,80 @@
 ---
-title: Talks and Conferences
+title: Recorded Talks
 date: 2018-05-05T10:36:00+02:00
 description: Talks at Meetups and Conferences
 weight: 20
 ---
-* [2019-12-05 Progressive Delivery   with Jenkins X](https://devopsworldjenkinsworld2019lisbo.sched.com/event/VDQ0/progressive-delivery-with-jenkins-x) at [Devops World, Lisboa](https://www.cloudbees.com/devops-world) by [Carlos Sanchez](https://csanchez.org)
+* [2019-10-03 The Recipe For Continuous Delivery](https://2019.devopsunicorns.com/sessions/the-recipe-to-continuous-delivery/) at [DevOps Unicorns](https://2019.devopsunicorns.com/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://youtu.be/YuGEAmPj_Fw)
 
-* [2019-12-02/3/4/5 GitOps by courtesy of Jenkins-X](https://devopsconference.de/kubernetes-ecosystem/gitops-by-courtesy-of-jenkins-x/) at [DevOpsCon 2019, München (Germany)](https://devopsconference.de/) by [Gerd Aschemann](https://twitter.com/GerdAschemann)
+* [2019-10-01 Choosing The Right Deployment Strategy](https://www.devclub.lv/announcement-of-devops-unicorns-warmup-79th-devclub-lv/) at [DevClub Riga](https://www.devclub.lv/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://www.youtube.com/watch?v=5MTx-xL6iQ0)
 
-* [2019-11-13 Progressive Delivery: Continuous Delivery the Right Way](https://cfp.devoxx.ma/2019/speaker/carlos_sanchez) at [Devoxx Morocco, Agadir](https://www.devoxx.ma/) by [Carlos Sanchez](https://csanchez.org)
+* [2019-09-11 Jenkins X: Progressive Delivery for Kubernetes](https://2019.javazone.no/program/d8f893f0-3e08-41ef-9ec6-fe2fa93cd4ce) at [JavaZone](https://2019.javazone.no) by [Carlos Sanchez](https://csanchez.org) [🎥 Vimeo](https://vimeo.com/362768726)
 
-* [2019-11-06 Jenkins X: Progressive Delivery for Kubernetes](https://oredev.org/line-up/carlos-sanchez) at [Oredev, Malmo](https://oredev.org) by [Carlos Sanchez](https://csanchez.org)
+* [2019-05-27 Running Serverless Continuous Delivery](https://www.jbcnconf.com/2019/infoTalk.html?id=5cd1f98438da161cb0381424) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://youtu.be/PEmsqzbiNFc)
 
-* [2019-10-03 The Recipe For Continuous Delivery](https://2019.devopsunicorns.com/sessions/the-recipe-to-continuous-delivery/) at [DevOps Unicorns](https://2019.devopsunicorns.com/) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-07-18 Progressive Delivery en Kubernetes (Spanish)](https://www.youtube.com/watch?v=u7Z1V_NcmPY)🎥 with [NorthemQuality](https://northemquality.github.io/) by [Carlos Sanchez](https://csanchez.org)
 
-* [2019-10-02 Cloud-Native Kubernetes-First Serverless Continuous Delivery With Jenkins X, Kubernetes, And Friends](https://2019.devopsunicorns.com/sessions/cloud-native-kubernetes-first-serverless-continuous-delivery-with-jenkins-x-kubernetes-and-friends/) at [DevOps Unicorns](https://2019.devopsunicorns.com/) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-07-04 Modern CI/CD with Tekton and Prow Automated via Jenkins X](https://kccnceu19.sched.com/event/MPZ4?iframe=no) at [KubeCon (Barcelona)](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/) by [Christie Wilson ](https://twitter.com/bobcatwilson) and [James Rawlings](https://twitter.com/jdrawlings) [🎥 YouTube](https://www.youtube.com/watch?v=4EyTGYB7GvA)
 
-* [2019-10-01 Choosing The Right Deployment Strategy](https://www.devclub.lv/announcement-of-devops-unicorns-warmup-79th-devclub-lv/) at [DevClub Riga](https://www.devclub.lv/) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-06-25 GitOps by courtesy of Jenkins-X](https://containerdays.sched.com/event/Q4Oc/gitops-by-courtesy-of-jenkins-x) at [ContainerDays 2019, Hamburg (Germany)](https://www.containerdays.io/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) [🎥 YouTube](https://www.youtube.com/watch?v=XzZIeCrB8p0) ([Slides](http://aschemann.net/gerd/publications/jx-talk-condays-2019/))
 
-* [2019-09-28 Creating And Managing Serverless Deployments With Knative And Jenkins X](https://www.changecon.com/speaker/153) at [ChangeCon Zagreb](https://www.changecon.com) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-06-24 Progressive Delivery: Continuous Delivery the Right Way](https://cdsummitchina19.sched.com/event/QaSO/progressive-delivery-continuous-delivery-the-right-way) at [CDSummit China](https://cdsummitchina19.sched.com) by [Carlos Sanchez](https://csanchez.org) [🎥 YouTube](https://www.youtube.com/watch?v=-3VHVsgBTyo&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=2)
 
-* [2019-09-19 Combining Serverless Continuous Delivery With ChatOps](https://www.meetup.com/es/SVQJUG/events/263195348/) at [Sevilla Java User Group](https://www.meetup.com/es/SVQJUG/) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-06-13 The recipe for continuous delivery](https://www.meetup.com/Cloud-Native-Computing-Bern/events/260536132/) at [Cloud Native Bern](https://www.meetup.com/Cloud-Native-Computing-Bern/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://www.youtube.com/watch?v=mPcQ4MY35go)
 
-* [2019-09-12 Dev and Run Small Projects on K8S with GitOps and Jenkins-X](https://helmsummit2019.sched.com/event/S8sk/dev-and-run-small-projects-on-k8s-with-gitops-and-jenkins-x-gerd-aschemann-independent) at [Helm Summit, Amsterdam (The Netherlands))](https://events.linuxfoundation.org/events/helm-summit-2019/) by [Gerd Aschemann](https://twitter.com/GerdAschemann)
+* [2019-06-24 Serverless Jenkins on Kubernetes - Jenkins X](https://sched.co/Nrmd) at [KubeCon CloudNativeCon 2019 (China)](https://www.lfasiallc.com/events/kubecon-cloudnativecon-china-2019/) by [RunZe Xia](https://github.com/runzexia) [🎥 YouTube](https://www.youtube.com/watch?v=oHz6pBuvchE&t=3s)
 
-* [2019-09-11 Jenkins X: Progressive Delivery for Kubernetes](https://2019.javazone.no/program/d8f893f0-3e08-41ef-9ec6-fe2fa93cd4ce) at [JavaZone](https://2019.javazone.no) [Vimeo 🎥](https://vimeo.com/362768726) by [Carlos Sanchez](https://csanchez.org)
+* [2019-06-11 Cloud Native CI/CD with Jenkins X and Tekton Pipelines](https://www.youtube.com/watch?v=f1wVRnao-BE) on [Jenkins-X YouTube](https://www.youtube.com/channel/UCN2kblPjXKMcjjVYmwvquvg/) by [Christie Wilson](https://twitter.com/bobcatwilson) and [James Rawlings](https://twitter.com/jdrawlings) [🎥 YouTube](https://www.youtube.com/watch?v=f1wVRnao-BE)
 
-* [2019-09-02 Jenkins X - Continuously Driving the Kloud](https://programm.doag.org/godevops/2019/#/scheduledEvent/587266) at [GoDevOps 2019, Berlin (Germany)](https://godevops.doag.org/de/home/) by [Gerd Aschemann](https://twitter.com/GerdAschemann)
+* [2019-05-27: Running Serverless Continuous Delivery](http://www.jbcnconf.com/2019/infoTalk.html?id=5cd1f98438da161cb0381424) at [JBCNConf](http://www.jbcnconf.com/2019/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://www.youtube.com/watch?v=PEmsqzbiNFc)
 
-* [2019-08-21 Jenkins X - Continuously Delivery for the Kloud](http://java.de/roller/blog/page/stammtisch_goettingen) at [Java User Group Deutschland/Göttingen (Germany)](http://java.de/) by [Gerd Aschemann](https://twitter.com/GerdAschemann)
+* [2019-04-24 Jenkins X: Continous Delivery for Kubernetes](https://voxxeddays.com/minsk/) at [Voxxed Days Minsk](https://voxxeddays.com/minsk/) by [Carlos Sanchez](https://csanchez.org) [🎥 YouTube](https://www.youtube.com/watch?v=wb2PK5uf5uI&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=4)
 
-* [2019-08-14 GitOps](https://devopsworldjenkinsworld2019.sched.com/event/TQb8/gitops) at [DevOps World San Francisco](https://www.cloudbees.com/devops-world/san-francisco) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-03-26 Ten Commandments Of GitOps Applied To Continuous Delivery](https://www.meetup.com/Barcelona-Jenkins-Area-Meetup/events/259869827/) at [Barcelona Jenkins Area Meetup](https://www.meetup.com/Barcelona-Jenkins-Area-Meetup/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://www.youtube.com/watch?v=PtC6YvoL_W8&t=2s)
 
-* [2019-08-14 Ten Commandments Of GitOps Applied To Continuous Delivery](https://devopsworldjenkinsworld2019.sched.com/event/SeVd/ten-commandments-of-gitops-applied-to-continuous-delivery) at [DevOps World San Francisco](https://www.cloudbees.com/devops-world/san-francisco) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-03-06 Cloud Native CI/CD for Kubernetes with JenkinsX](https://www.meetup.com/Dubai-Jenkins-Area-Meetup/events/258523035/) at [Jenkins Area Meetup(JAM) Dubai](https://www.meetup.com/Dubai-Jenkins-Area-Meetup/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://www.youtube.com/watch?v=PtC6YvoL_W8) 
 
-* [2019-08-13 Continuous Delivery with Jenkins X](https://devopsworldjenkinsworld2019.sched.com/event/S6hP/400-continuous-delivery-with-jenkins-x) at [DevOps World San Francisco](https://www.cloudbees.com/devops-world/san-francisco) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-03-05 Cloud Native CI/CD with Jenkins X and Tekton Pipelines](https://qconlondon.com/london2019/presentation/cloud-native-cicd-jenkins-x-and-knative-pipelines) at [QConLondon](https://qconlondon.com/) by [James Rawlings](https://twitter.com/jdrawlings) and [Christie Wilson](https://twitter.com/bobcatwilson) [slides](https://qconlondon.com/system/files/presentation-slides/cloud_native_ci_cd_with_jenkins_x_and_knative_pipelines.pdf) [🎥 InfoQ](https://www.infoq.com/presentations/cloud-native-ci-cd-jenkins-knative/?utm_source=presentations&utm_medium=london&utm_campaign=qcon)
 
-* [2019-08-12 Continuous Delivery with Jenkins X](https://devopsworldjenkinsworld2019.sched.com/event/S6hG/400-continuous-delivery-with-jenkins-x) at [DevOps World San Francisco](https://www.cloudbees.com/devops-world/san-francisco) by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2019-02-28 Jenkins X: Continuous Delivery for Kubernetes](https://www.youtube.com/watch?v=hrridH35y64&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&t=0s&index=2) by [Carlos Sanchez](https://csanchez.org) [🎥 YouTube](https://www.youtube.com/watch?v=hrridH35y64&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&t=0s&index=2)
 
-* [2019-08-08 Jenkins-X - CD for the Kloud](https://www.meetup.com/Java-User-Group-Saarland-jugsaar/events/262962734/) at [Java User Group Saarland (Germany)](https://www.meetup.com/Java-User-Group-Saarland-jugsaar/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-jugsb-2019))
+* [2019-01-14 Jenkins X - Continuously Driving the Kloud (German)](https://www.meetup.com/de-DE/DevOps-Wuerzburg-Mainfranken/events/255614733/) at [DevOps Meetup Würzburg (Germany)](https://www.meetup.com/DevOps-Wuerzburg-Mainfranken/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) - ([🎥 YouTube](https://www.youtube.com/watch?v=NDIut5uYVS0), [Slides](http://aschemann.net/gerd/publications/jx-talk-devops-wue-2019/))
 
-* 2019-07-18 Progressive Delivery en Kubernetes (Spanish) [YouTube 🎥](https://www.youtube.com/watch?v=u7Z1V_NcmPY&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=3) by [Carlos Sanchez](https://csanchez.org)
+* [2018-12-12 KubeCon NA Seattle: Jenkins X: Continuous Delivery for Kubernetes](http://sched.co/GrT2) by [Carlos Sanchez](https://csanchez.org) [🎥 YouTube](https://www.youtube.com/watch?v=IDEa8seAzVc&index=1&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO)
 
-* 2019-07-06 Jenkins X: Why, What, And How at DOIS Beijing by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2018-12-05 Jenkins x Kubernetesが簡単だと思ったら大変だった話 (Japanese)](https://www.slideshare.net/YamamotoMasaki/jenkins-x-kubernetes) at [JapanContainerDays v18.12](https://containerdays.jp/) by [Masaki Yamamoto](https://blog.nnasaki.com/) [🎥 YouTube](https://www.youtube.com/watch?v=3-1MKJE6_mI)
 
-* 2019-07-04 Jenkins X Workshop at DOIS Beijing by [Viktor Farcic](https://twitter.com/vfarcic)
+* [2018-11-23 CommitConf Madrid: Jenkins X: Continuous Delivery for Kubernetes (Spanish)](https://www.koliseo.com/events/commit-2018/r4p/5630471824211968/agenda#/5116072650866688/5742659054338048) by [Carlos Sanchez](https://csanchez.org) [🎥 YouTube](https://youtu.be/_FDl0wAxDME)
 
-* 2019-06-19 The recipe for continuous delivery at [EuroDog Brussels](https://nadevops.com/eurodog) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-06-24 Progressive Delivery: Continuous Delivery the Right Way](https://cdsummitchina19.sched.com/event/QaSO/progressive-delivery-continuous-delivery-the-right-way) at [CDSummit China](https://cdsummitchina19.sched.com) [YouTube 🎥](https://www.youtube.com/watch?v=-3VHVsgBTyo&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=2) by [Carlos Sanchez](https://csanchez.org)
-
-* [2019-06-13 The recipe for continuous delivery](https://www.meetup.com/Cloud-Native-Computing-Bern/events/260536132/) at [Cloud Native Bern](https://www.meetup.com/Cloud-Native-Computing-Bern/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-06-12 The recipe for continuous delivery](https://www.meetup.com/Lausanne-CI-CD-and-DevOps/events/261586221/) at [Lausanne CI/CD and DevOps](https://www.meetup.com/Lausanne-CI-CD-and-DevOps/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-07-04 Modern CI/CD with Tekton and Prow Automated via Jenkins X](https://www.youtube.com/watch?v=4EyTGYB7GvA) at [KubeCon (Barcelona)](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/) by [Christie Wilson ](https://twitter.com/bobcatwilson) and [James Rawlings](https://twitter.com/jdrawlings)
-
-* [2019-07-04 Jenkins-X - CI/CD für die Kloud (German)](https://www.java-forum-stuttgart.de/de/Vortr%E4ge+von+16.40+-+17.25+Uhr.html#D7) at [Java Forum Stuttgart (Germany)](https://www.java-forum-stuttgart.de/de/Konferenz.html) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-javaforum-stuttgart-2019/))
-
-* [2019-06-25 GitOps by courtesy of Jenkins-X](https://containerdays.sched.com/event/Q4Oc/gitops-by-courtesy-of-jenkins-x) at [Container Days, Hamburg (Germany)](https://www.containerdays.io/¡) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-condays-2019/))
-
-* [2019-06-24 Serverless Jenkins on Kubernetes - Jenkins X](https://sched.co/Nrmd) at [KubeCon CloudNativeCon 2019 (China)](https://www.lfasiallc.com/events/kubecon-cloudnativecon-china-2019/) by [RunZe Xia](https://github.com/runzexia)
-
-* [2019-06-11 The Recipe for Continuous Delivery](https://www.eventbrite.com/e/zurich-devops-and-hops-tickets-61928848854#) at [EuroDog Zurich](https://nadevops.com/eurodog) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* 2019-06-06 Talk: Jenkins X: Toward a Cloud-Native Jenkins at [WeAreDevelopers](https://events.wearedevelopers.com/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* 2019-06-05 Workshop: Cloud-Native Kubernetes-First Continuous Delivery With Jenkins X, Kubernetes, And Friends at [WeAreDevelopers](https://events.wearedevelopers.com/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-06-06 Continuous Delivery mit Jenkins X und Kubernetes](https://www.devops-essentials.de/lecture.php?id=7929-continuous-delivery-mit-jenkins-x-und) at [DevOps Essentials 2019](https://www.devops-essentials.de/) by [Nicolas Byl](https://twitter.com/NicolasByl)
-
-* 2019-05-30: Cloud-Native Kubernetes-First Continuous Delivery With Jenkins X, Kubernetes, And Friends at [ShiftDev](https://dev.shiftconf.co/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-05-27: Running Serverless Continuous Delivery](http://www.jbcnconf.com/2019/infoTalk.html?id=5cd1f98438da161cb0381424) at [JBCNCconf](http://www.jbcnconf.com/2019/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-06-04 Jenkins X: Progressive Delivery for Kubernetes](https://jnation.pt/speakers/carlos-sanchez/) at [JNation (Coimbra, Portugal)](https://jnation.pt) by [Carlos Sanchez](https://csanchez.org)
-
-* [2019-05-28 GitOps by courtesy of Jenkins-X](https://gr8conf.eu/talks/760) at [gr8conf (Copenhagen/Denmark)](https://gr8conf.eu/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-gr8conf-2019/))
-
-* [2019-04-24 Jenkins X: Continous Delivery for Kubernetes](https://voxxeddays.com/minsk/) [YouTube 🎥](https://www.youtube.com/watch?v=wb2PK5uf5uI&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=4) at [Voxxed Days Minsk](https://voxxeddays.com/minsk/) by [Carlos Sanchez](https://csanchez.org)
-
-* [2019-05-23 CI/CD on Kubernetes with Jenkins X](https://docs.google.com/spreadsheets/d/1mA0FDySf2t2sSjKKG2VOta8vDDiGsQytgxJ2iHBeDIs/edit#gid=0&range=D52:E52) at [GlueCon](http://gluecon.com/) by [Nicholas Duffy](https://twitter.com/duffn)
-
-* [2019-05-07 Workshop: Continuous Deployment To Kubernetes](https://craft-conf.com/workshops) at [Craft (Budapest)](https://craft-conf.com/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-03-28 Cloud-Native Kubernetes-First Continuous Delivery With Jenkins X](https://www.meetup.com/Lisbon-Jenkins-Area-Meetup/events/259936138/?_xtd=gatlbWFpbF9jbGlja9oAJDM3ODY0M2Q4LWY3ZmItNGQ5ZS05YWNhLTQ2ZTM3ODdkZGY0Yg) at [Lisbon Jenkins Area Meetup](https://www.meetup.com/Lisbon-Jenkins-Area-Meetup/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-03-26 Ten Commandments Of GitOps Applied To Continuous Delivery](https://www.meetup.com/Barcelona-Jenkins-Area-Meetup/events/259869827/) at [Barcelona Jenkins Area Meetup](https://www.meetup.com/Barcelona-Jenkins-Area-Meetup/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-03-20 Cloud-Native Kubernetes-First Continuous Delivery With Jenkins X](https://www.meetup.com/DevOps-Freiburg/events/259091235/) at [DevOps Meetup Freiburg](https://www.meetup.com/DevOps-Freiburg/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-03-19 Jenkins X - Continuously Driving the Kloud (German)](https://programm.javaland.eu/2019/#/scheduledEvent/569771) at [Javaland 2019 (Germany)](https://www.javaland.eu) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-javaland-2019/))
-
-* [2019-03-06 Cloud Native CI/CD for Kubernetes with JenkinsX](https://www.meetup.com/Dubai-Jenkins-Area-Meetup/events/258523035/) at [Jenkins Area Meetup(JAM) Dubai](https://www.meetup.com/Dubai-Jenkins-Area-Meetup/) by [Viktor Farcic](https://twitter.com/vfarcic) 
-
-* [2019-03-05 Cloud Native CI/CD with Jenkins X and Tekton Pipelines](https://qconlondon.com/london2019/presentation/cloud-native-cicd-jenkins-x-and-knative-pipelines) at [QConLondon](https://qconlondon.com/) by [James Rawlings](https://twitter.com/jdrawlings) and [Christie Wilson](https://twitter.com/bobcatwilson) [slides](https://qconlondon.com/system/files/presentation-slides/cloud_native_ci_cd_with_jenkins_x_and_knative_pipelines.pdf)
-
-* [2019-02-28 Jenkins X: Continuous Delivery for Kubernetes](https://www.youtube.com/watch?v=hrridH35y64&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&t=0s&index=2) [YouTube 🎥](https://www.youtube.com/watch?v=hrridH35y64&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&t=0s&index=2) by [Carlos Sanchez](https://csanchez.org)
-
-* [2019-02-26 GitOps by courtesy of Jenkins-X (German)](https://www.meetup.com/Agile-Testing-Munich/events/258881963/) at [Agile Testing @Munich (Germany)](https://www.meetup.com/Agile-Testing-Munich/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-munich-agile-testing-2019/))
-
-* [2019-02-19 Cloud Native Computing Paris: CI/CD with Jenkins X](https://www.meetup.com/Cloud-Native-Computing-Paris/events/258880938/) by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2019-01-24 Jenkins X - Continuously Driving the Kloud (German)](https://www.xing.com/events/jenkins-continuously-driving-the-kloud-1995467?sc_o=si1942_com) at [JUG Metroplregion Nürnberg (Germany)](http://www.jug-n.de) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-jug-met-n-2019/))
-
-* [2019-01-23 Introduction to Jenkins X and opinionated CI/CD](https://www.slideshare.net/michaelneale/jenkins-x-intro-from-google-app-dev-conference) at Google Digital AppDev conference (Singapore) by [Michael Neale](https://twitter.com/michaelneale)
-
-* [2019-01-14 Jenkins X - Continuously Driving the Kloud (German)](https://www.meetup.com/de-DE/DevOps-Wuerzburg-Mainfranken/events/255614733/) at [DevOps Meetup Würzburg (Germany)](https://www.meetup.com/DevOps-Wuerzburg-Mainfranken/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) - ([Youtube Stream](https://www.youtube.com/watch?v=NDIut5uYVS0), [Slides](http://aschemann.net/gerd/publications/jx-talk-devops-wue-2019/))
-
-* [2019-02-01 Continuous Deployment with Jenkins X, Kubernetes, and Friends](https://www.eventbrite.com/e/workshop-continuous-deployment-with-jenkins-x-kubernetes-and-friends-tickets-54562126790) at Fosdem, Brussels by [Viktor Farcic](https://twitter.com/vfarcic)
-
-* [2018-12-19 Jenkins X - Continuously Driving the Kloud (German)](https://sites.google.com/site/jugffm/home/19-12-2018-jenkins-x---continuously-driving-the-kloud) at [JUG Frankfurt (Germany)](https://sites.google.com/site/jugffm/home) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-jugffm-2018/))
-
-* [2018-12-12 KubeCon NA Seattle: Jenkins X: Continuous Delivery for Kubernetes](http://sched.co/GrT2) [YouTube 🎥](https://www.youtube.com/watch?v=IDEa8seAzVc&index=1&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO) by [Carlos Sanchez](https://csanchez.org)
-
-* [2018-12-05 Jenkins x Kubernetesが簡単だと思ったら大変だった話 (Japanese)](https://www.slideshare.net/YamamotoMasaki/jenkins-x-kubernetes) at [JapanContainerDays v18.12](https://containerdays.jp/)  [YouTube 🎥](https://www.youtube.com/watch?v=3-1MKJE6_mI) by [Masaki Yamamoto](https://blog.nnasaki.com/)
-
-* [2018-11-23 CommitConf Madrid: Jenkins X: Continuous Delivery for Kubernetes](https://www.koliseo.com/events/commit-2018/r4p/5630471824211968/agenda#/5116072650866688/5742659054338048) by [Carlos Sanchez](https://csanchez.org)
-
-* [2018-11-17 Korea Developer Conference at Seoul: Jenkins X - automated CI/CD solution for cloud native applications on Kubernetes](http://www.hanbit.co.kr/store/education/edu_view.html?p_code=S8548956082) on [JBUG Korea](https://www.facebook.com/groups/jbossusergroup/) with [slides](https://www.slideshare.net/tedwon/jenkins-x-automated-cicd-solution-for-cloud-native-applications-on-kubernetes-123332546) by [Ted Won](https://twitter.com/tedwon)
-
-* [2018-11-15 DevOpsPro Moscow: Using Kubernetes for Continuous Integration and Continuous Delivery](https://www.devopspro.ru/carlos-sanchez/) by [Carlos Sanchez](https://csanchez.org)
-
-* [2018-11-14: Jenkins X at KubeCon CloudNativeCon China 2018](https://linuxsuren.github.io/opensource/2018-KubeCon-Shanghai-jenkinsx.pdf) by [Zhao Xiaojie](https://github.com/linuxsuren)
-
-* [2018-11-14 Meetup Munich: Continuous Applications Delivery for Kubernetes](https://www.meetup.com/munchen-jenkins-area-meetup/events/255633850/) by [Cosmin Cojocar](https://github.com/ccojocar)
+* [2018-11-15 DevOpsPro Moscow: Using Kubernetes for Continuous Integration and Continuous Delivery](https://www.devopspro.ru/carlos-sanchez/) by [Carlos Sanchez](https://csanchez.org) [🎥 YouTube](https://www.youtube.com/watch?v=p7fuJONFyeY&list=PLqYhGsQ9iSEq6jC6bxW_q7ezr16TpLRwR&index=25&t=0s)
 
 * [2018-11-14 Jenkins X - Continuously Driving the Kloud (German)](https://www.continuouslifecycle.de/veranstaltung-7488-jenkins-x-%E2%80%93-continuously-driving-the-kloud.html?id=7488) at [Continuous Lifecycle (Mannheim, Germany)](https://www.continuouslifecycle.de/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-conli-2018/))
 
-* [2018-10-18 Jenkins X - Continuously Driving the Kloud (German)](https://www.baselone.ch/speech/B6A3BA74-8E28-46CD-B4B7-F96C6FFE0B39/Jenkins-X---Continuously-Driving-the-Kloud) at [BaselOne (Basel, Switzerland)](https://www.baselone.ch/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-baselone-2018/))
+* [2018-10-13 Jenkins X - Continuously Driving the Kloud (German)](https://openspacer.org/60-devops-community/222-devops-camp-compact-2018/session/926-jenkins-x/) at [Devops Camp Compact 2018 Nürnberg (Germany)](https://devops-camp.de/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) - [🎥 YouTube Stream of Part 1](https://youtu.be/hqg7mbjBDTo?t=13352&end=16578) ([Slides](http://aschemann.net/gerd/publications/jx-talk-docc-2018/))
 
-* [2018-10-15 Jenkins X - Continuously Driving the Kloud (German)](https://www.meetup.com/Frankfurt-am-Main-Kubernetes-Meetup/events/254372021/) at [Kubernetes Meetup Frankfurt a.M. (Germany)](https://www.meetup.com/Frankfurt-am-Main-Kubernetes-Meetup/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-k8s-ffm-2018/))
+* [2018-09-29 Software Crafters, Barcelona, Spain: Continuous Deployment With Jenkins X And Kubernetes](https://scbcn.github.io) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://youtu.be/zoT8FyqITLI)
 
-* [2018-10-13 Jenkins X - Continuously Driving the Kloud (German)](https://openspacer.org/60-devops-community/222-devops-camp-compact-2018/session/926-jenkins-x/) at [Devops Camp Compact 2018 Nürnberg (Germany)](https://devops-camp.de/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) - [Youtube Stream of Part 1](https://youtu.be/hqg7mbjBDTo?t=13352&end=16578) ([Slides](http://aschemann.net/gerd/publications/jx-talk-docc-2018/))
-
-* [2018-11-14 Meetup Zurich: Continuous Applications Delivery for Kubernetes](https://www.meetup.com/Swiss-Jenkins-Area-Meetup/events/254221707/) by [Cosmin Cojocar](https://github.com/ccojocar)
-
-* [2018-09-29 Software Crafters, Barcelona, Spain: Continuous Deployment With Jenkins X And Kubernetes](https://scbcn.github.io) by [Viktor Farcic](https://twitter.com/vfarcic) [Video](https://youtu.be/zoT8FyqITLI)
-
-* [2018-10-08 JDD Poland: End to End automation and Continuous Delivery of Microservices for Kubernetes](http://bit.ly/jdd-conference-jx) by [Paolo Carta](https://twitter.com/cl4mer) with [Video](http://bit.ly/video-jdd-jx)
-
-* [2018-09-28 XantarJ Santiago de Compostela: Acelera el desarrollo de tus aplicaciones con Docker y Jenkins](https://www.eventbrite.es/e/entradas-xantarj-2018-49884037499) by [Carlos Sanchez](https://csanchez.org)
-
-* [2018-09-13 Workshop Days Switzerland: Jenkins X: Continuous Delivery for Java services in Kubernetes](https://workshoptage.ch/workshops/2018/jenkins-x-continuous-delivery-for-java-services-in-kubernetes/) by [Cosmin Cojocar](https://twitter.com/CojocarCosmin)
-
-* [2018-09-12 Workshop Days Switzerland: End-to-End Continuous Delivery on Kubernetes](http://bit.ly/workshop-ci-cd-jx) by [Paolo Carta](https://twitter.com/cl4mer) and Matteo Baiguini
+* [2018-10-08 JDD Poland: End to End automation and Continuous Delivery of Microservices for Kubernetes](http://bit.ly/jdd-conference-jx) by [Paolo Carta](https://twitter.com/cl4mer) with [🎥 YouTube](https://www.youtube.com/watch?v=Twg6Ld3niW0)
 
 * [2018-09-12 JavaZone: Using Kubernetes for Continuous Integration and Continuous Delivery](https://2018.javazone.no/program/7f3694e6-1936-4d14-9ac1-2b1f7585da41) 🎥 by [Carlos Sanchez](https://csanchez.org)
 
-* [2018-09-12 Jenkins X - Continuously Driving the Kloud (German)](http://www.jug-kl.de/jenkins/) at [JUG Kaiserslautern (Germany)](http://www.jug-kl.de/) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-jugkl-2018/))
+* [2018-06-30 CI/CD for Spring Boot Applications with Jenkins X](http://perujug.org/perujavaday2018/) at JavaDay Perú by [Eddú Meléndez](https://twitter.com/eddumelendez) [🎥 YouTube](https://www.youtube.com/watch?v=zCdCx5tCvtc)
 
-* [2018-09-08 JavaDay Ecuador: CI/CD for Spring Boot Applications with Jenkins X](https://www.javaday.ec/) by [Eddú Meléndez](https://twitter.com/eddumelendez)
+* [2018-06-11 Jenkins X: Continuous Delivery for Kubernetes](http://www.jbcnconf.com/2018/infoTalk.html?id=37)🎥 at [JBCNConf 2018](http://www.jbcnconf.com/2018/) by [James Strachan](https://twitter.com/jstrachan)
 
-* [2018-09-06 Jenkins X - Continuously Driving the Kloud (German)](http://bed-con.org/2018/programm) at [Bed-Con: Berlin Expert Days 2018 (Germany)](http://bed-con.org/2018) by [Gerd Aschemann](https://twitter.com/GerdAschemann) ([Slides](http://aschemann.net/gerd/publications/jx-talk-bedcon-2018/))
+* [2018-06-05 Continuous Integration and Delivery with Kubernetes](https://www.youtube.com/watch?v=bIdMveCe75c&feature=youtu.be)🎥 by [CNCF](https://www.cncf.io/) by [James Strachan](https://twitter.com/jstrachan) [slides](https://docs.google.com/presentation/d/1hwt2lFh3cCeFdP4xoT_stMPs0nh2xVZUtze6o79WfXc/edit?usp=sharing)
 
-* [JavaDay Perú 30 June 2018:CI/CD for Spring Boot Applications with Jenkins X](http://perujug.org/perujavaday2018/) by [Eddú Meléndez](https://twitter.com/eddumelendez)
+* [2018-06-05 Jenkins X: Continuous Delivery for Kubernetes](https://www.youtube.com/watch?time_continue=1&v=53AtxQGXnMk)🎥 on [@virtualJUG](https://twitter.com/virtualJUG) with [slides](https://docs.google.com/presentation/d/1hwt2lFh3cCeFdP4xoT_stMPs0nh2xVZUtze6o79WfXc/edit?usp=sharing) by [James Strachan](https://twitter.com/jstrachan)
 
-* [JBCN Conference 11-13 June 2018:Workshop - building Continuous Delivery for Microservices with Jenkins X](http://www.jbcnconf.com/2018/infoSpeaker.html?ref=SmFtZXNTdHJhY2hhbmpzdHJhY2hhbkBjbG91ZGJlZXMuY29t) by [James Strachan](https://twitter.com/jstrachan)
+* [Devoxx UK: Jenkins X: Continuous Delivery for Kubernetes](https://cfp.devoxx.co.uk/2018/talk/XWT-9637/Jenkins_X:_Continuous_Delivery_for_Kubernetes) by [James Strachan](https://twitter.com/jstrachan) [🎥 YouTube](https://www.youtube.com/watch?v=BF3MhFjvBTU)
 
-* [CNCF webinar: Continuous Integration and Delivery with Kubernetes](https://www.youtube.com/watch?v=bIdMveCe75c&feature=youtu.be) with [slides](https://docs.google.com/presentation/d/1hwt2lFh3cCeFdP4xoT_stMPs0nh2xVZUtze6o79WfXc/edit?usp=sharing) by [James Strachan](https://twitter.com/jstrachan)
+* [2018-05-31 Dev Days, Riga: Continuous Deployment With Jenkins X And Kubernetes](https://rigadevdays.lv/) by [Viktor Farcic](https://twitter.com/vfarcic) [🎥 YouTube](https://youtu.be/iughcmtWz8s)
 
-* [VirtualJUG: Jenkins X: Continuous Delivery for Kubernetes](https://www.youtube.com/watch?time_continue=1&v=53AtxQGXnMk) on [@virtualJUG](https://twitter.com/virtualJUG) with [slides](https://docs.google.com/presentation/d/1hwt2lFh3cCeFdP4xoT_stMPs0nh2xVZUtze6o79WfXc/edit?usp=sharing) by [James Strachan](https://twitter.com/jstrachan)
+* [2018-05-04 Jenkins X:Easy CI/CD for Kubernetes](https://www.youtube.com/watch?v=uHe7R_iZSLU)🎥 at [KubeCon + CloudNativeCon Europe 2018](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2018/) by [James Strachan](https://twitter.com/jstrachan)
 
-* [JBCN Conference 11-13 June 2018:Jenkins X: Continuous Delivery for Kubernetes](http://www.jbcnconf.com/2018/infoSpeaker.html?ref=Um9iZXJ0RGF2aWVzcmRhdmllc0BjbG91ZGJlZXMuY29t) by [Rob Davies](https://twitter.com/rajdavies) and [JamesRawlings](https://twitter.com/jdrawlings) with [slides](https://docs.google.com/presentation/d/1i0JTVaMGCD4pPuOOE0wIfYgbUU40qSmissu0UnizpVQ/edit?usp=sharing)
+* [2018-04-19 Devoxx France: Using Kubernetes for Continuous Integration and Continuous Delivery](https://www.youtube.com/watch?v=jls74bflA3s&t=0s&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=2)🎥 by [Carlos Sanchez](https://csanchez.org)
 
-* [Devoxx UK: Jenkins X: Continuous Delivery for Kubernetes](https://cfp.devoxx.co.uk/2018/talk/XWT-9637/Jenkins_X:_Continuous_Delivery_for_Kubernetes) by [James Strachan](https://twitter.com/jstrachan)
-
-* [2018-05-31 Dev Days, Riga: Continuous Deployment With Jenkins X And Kubernetes](https://rigadevdays.lv/) by [Viktor Farcic](https://twitter.com/vfarcic) [Video](https://youtu.be/iughcmtWz8s)
-
-* [Cloud Native Meetup, Wales 10 May 2018: Jenkins X: Easy CI/CD for Kubernetes](https://www.meetup.com/Cloud-Native-Wales/events/lxwbppyxhbnb/) by [James Rawlings](https://twitter.com/jdrawlings)
-
-* [KubeCon EU 2-4 May 2018: Jenkins X:Easy CI/CD for Kubernetes](https://www.youtube.com/watch?v=uHe7R_iZSLU) by [James Strachan](https://twitter.com/jstrachan)
-
-* [London Jenkins Meetup 24 April 2018: Jenkins X: Automated CI/CD for Kubernetes](https://www.meetup.com/London-Jenkins-Area-Meetup/) by [James Strachan](https://twitter.com/jstrachan)
-
-* [2018-04-19 Devoxx France: Using Kubernetes for Continuous Integration and Continuous Delivery](https://www.youtube.com/watch?v=jls74bflA3s&t=0s&list=PLHsuXkXI4xdjGlGkCBdxIAmkzfWXqsUrO&index=2) 🎥 by [Carlos Sanchez](https://csanchez.org)
-
-* [Kubernetes Meetup, London  12 Apriul 2018: CI/CD with Jenkins X on Kubernetes](https://skillsmatter.com/skillscasts/11833-kubernetes-april) by [Rob Davies](https://twitter.com/rajdavies) and [JamesRawlings](https://twitter.com/jdrawlings)
+* [2018-04-12 CI/CD with Jenkins X on Kubernetes](https://skillsmatter.com/skillscasts/11833-kubernetes-april)🎥 at [Kubernetes Meetup, London](https://skillsmatter.com/meetups/10867-kubernetes-april)  by [Rob Davies](https://twitter.com/rajdavies) and [JamesRawlings](https://twitter.com/jdrawlings)
 
 
 Also check out the [Jenkins X Blog](/news/) and [Articles](/docs/getting-started/demos-talks-posts/articles/)


### PR DESCRIPTION
Resolves #2132 by removing all talks from the "Getting Started" section for which video recordings could not be found. These talks are already listed in the "Community" section.

I standardized the date format and found some extra video links here and there. The design could perhaps use some help in a future PR.