### PR TITLE
chore: improve example for git token 401

### DIFF
--- a/content/en/docs/managing-jx/faq/issues.md
+++ b/content/en/docs/managing-jx/faq/issues.md
@@ -169,8 +169,8 @@ This indicates your git API token either was input incorrectly or has been regen
 To recreate it with a new API token value try the following (changing the git server name to match your git provider):
 
 ```sh
-jx delete git token -n GitHub admin
-jx create git token -n GitHub admin
+jx delete git token -n github <yourUserName>
+jx create git token -n github <yourUserName>
 ```
 
 More details on [using git and Jenkins X here](/docs/managing-jx/common-tasks/git/)


### PR DESCRIPTION
The example used an invalid casing for the token (`-n GitHub`) which doesn't seem to work in real life.

To avoid confusion with the name `admin`, which can make people guess it is a pre-configured value, I've replaced it with `<yourUserName>`, which is what it should be. This implies - correctly in my assumption - that you have to change this value to your git user name.