### PR TITLE
fix: removing aliases from spanish pages to avoid them clashing with the ones for english

### DIFF
--- a/content/es/blog/news/jenkins-x-new-logo.md
+++ b/content/es/blog/news/jenkins-x-new-logo.md
@@ -6,22 +6,21 @@ description: >
 categories: [blog]
 keywords: []
 slug: "new-logo-jenkins-x"
-aliases: []
 author: tracymiranda
 ---
-Back in March 2018, the Jenkins X project burst onto the scene as the Jenkins counterpart for automated CI/CD for Kubernetes. As part of that launch featured the logo: a variation of the Jenkins logo, featuring a pipe-smoking ship captain with Kubernetes logo on his cap. 
+Back in March 2018, the Jenkins X project burst onto the scene as the Jenkins counterpart for automated CI/CD for Kubernetes. As part of that launch featured the logo: a variation of the Jenkins logo, featuring a pipe-smoking ship captain with Kubernetes logo on his cap.
 
-In software, we like to say that naming is hard - because it is. Another thing that is also hard is trying to capture the essence of a project in a logo. Logos pack a lot of meaning into a small space. Icons, such as the Jenkins logo, establish a strong emotional connection with many developers. So with that in mind we always listened closely to feedback on the new logo and how people perceive the project as a result of it. 
+In software, we like to say that naming is hard - because it is. Another thing that is also hard is trying to capture the essence of a project in a logo. Logos pack a lot of meaning into a small space. Icons, such as the Jenkins logo, establish a strong emotional connection with many developers. So with that in mind we always listened closely to feedback on the new logo and how people perceive the project as a result of it.
 
 ## Why we are changing the logo
-In listening to various types of feedback from all sorts of different sources we heard many positive things but also some problems and confusion were highlighted. 
+In listening to various types of feedback from all sorts of different sources we heard many positive things but also some problems and confusion were highlighted.
 
-* Not everyone was a fan of the logo and we heard quite a few comments back about aspects that people didn’t like about it, with the ‘pipe-smoking’ featuring high on that list. 
+* Not everyone was a fan of the logo and we heard quite a few comments back about aspects that people didn’t like about it, with the ‘pipe-smoking’ featuring high on that list.
 * Confusion with Jenkins project - we also saw that the logo was more in keeping with A other Jenkins mascots, which led to confusion about what kind of project Jenkins X is - some perceived it as another plugin in the ecosystem.
-* We also heard that use of the Kubernetes logo was confusing or perhaps not completely within the remit of the Kubernetes logo guidelines. 
+* We also heard that use of the Kubernetes logo was confusing or perhaps not completely within the remit of the Kubernetes logo guidelines.
 * From a practical perspective we also heard that the logo was too detailed and as a result would not work well as an icon, especially for a favicon. It  was seen as more of a mascot than a logo.
 
-With the setup of the CD.Foundation and Jenkins X being one of the founding projects, distinct from Jenkins, we felt the time was right to address this feedback. So we literally went back to the drawing board to think about what logo could better represent Jenkins X as a project. We thought about what we want people to associate with the project: open source, continuous delivery, speed, automation, stability, teams, etc. We also wanted a logo that could improve representation, so we wanted to avoid a human-based logo that might inadvertently encode gender, age and other factors. Additionally, the 'X' has become a distinct part of the project's identity and so we wanted to really emphasize it in the new logo. 
+With the setup of the CD.Foundation and Jenkins X being one of the founding projects, distinct from Jenkins, we felt the time was right to address this feedback. So we literally went back to the drawing board to think about what logo could better represent Jenkins X as a project. We thought about what we want people to associate with the project: open source, continuous delivery, speed, automation, stability, teams, etc. We also wanted a logo that could improve representation, so we wanted to avoid a human-based logo that might inadvertently encode gender, age and other factors. Additionally, the 'X' has become a distinct part of the project's identity and so we wanted to really emphasize it in the new logo.
 
 ## Designing the new logo & community feedback
 Ultimately we focussed on trying to visualize speed and automation which led to the idea of a robot. However, we still wanted to have a nod to the original Jenkins project featured in the logo somehow or the other. We explicitly decided to not stick with the nautical theme traditionally associated with Kubernetes and related projects. We went through a few iterations, refining and cutting down details as we went. The design effort was a close partnership with Craig Ross, Creative Director at the Linux Foundation and his team, who also produced the [CD Foundation](https://cd.foundation/), CNCF, Network Service Mesh, and Tekton brands."
@@ -32,9 +31,9 @@ After the core Jenkins X team had settled on a design they were happy with, we t
 Jenkins X started life as a Jenkins subproject and is now an independent project with the Continuous Delivery Foundation (CDF). The bowtie in the new logo is an ever-present reminder of that provenance. Even though our logo and branding may be changing, under the umbrella of the CDF, we continue to work closely with the Jenkins project, sharing that same spirit of service towards developers’ CI/CD and productivity needs.
 
 ## Rolling out the new logo
-We have now started switching over to the new logo and expect to see some new swag available soon too. The old logo we will now consider as a mascot of the Jenkins X project. If you are looking to update your use of the logo, [here is the new artwork](https://github.com/cdfoundation/artwork). 
+We have now started switching over to the new logo and expect to see some new swag available soon too. The old logo we will now consider as a mascot of the Jenkins X project. If you are looking to update your use of the logo, [here is the new artwork](https://github.com/cdfoundation/artwork).
 
-<img src="/news/new-logo-jenkins-x/jenkinsx-stacked-color.png"> 
+<img src="/news/new-logo-jenkins-x/jenkinsx-stacked-color.png">
 
 It is a big change for the project but ultimately the reason we put so much time and energy into this is that is important to us we represent the spirit of Jenkins X in everything we do. So when you are using Jenkins X, and you see the new logo, we want you to feel part of the open and friendly community and we want your team to focus on what you really want to focus on: delivering quality software at speed and at any scale.
 

--- a/content/es/docs/_index.md
+++ b/content/es/docs/_index.md
@@ -5,6 +5,4 @@ weight: 20
 menu:
   main:
     weight: 20
-aliases:
-  - /documentation
 ---

--- a/content/es/docs/concepts/_index.md
+++ b/content/es/docs/concepts/_index.md
@@ -3,8 +3,6 @@ title: Conceptos
 linktitle: Conceptos
 description: Un resumen de los conceptos en Jenkins X.
 weight: 5
-aliases:
-  - /about/concepts
 ---
 
 Jenkins X está diseñado para simplificar el trabajo de los desarrolladores según los principios y las mejores prácticas de DevOps. Los enfoques adoptados se basan en la investigación exhaustiva realizada para el libro [*ACCELERATE: Building and Scaling High Performing Technology Organsiations*](https://goo.gl/vZ8BFN). Puedes leer por qué usamos [Accelerate](../overview/accelerate) como base para los principios de Jenkins X.

--- a/content/es/docs/concepts/jenkins-x-pipelines.md
+++ b/content/es/docs/concepts/jenkins-x-pipelines.md
@@ -3,9 +3,6 @@ title: Pipelines en Jenkins X
 linktitle: Pipelines en Jenkins X
 description: Flujo de actividades sin servidor (serverless) pensadas para la nube
 keywords: [tekton]
-aliases:
-  - /architecture/jenkins-x-pipelines
-  - /getting-started/next-gen-pipeline
 weight: 40
 ---
 

--- a/content/es/docs/contributing/_index.md
+++ b/content/es/docs/contributing/_index.md
@@ -3,8 +3,6 @@ title: Contribuye al Proyecto Jenkins X
 linktitle: Contribuye a Jenkins X
 description: Contribuye al desarrollo de Jenkins X y a su documentación.
 weight: 10
-aliases:
-  - /contribute
 ---
 
 Jenkins X relies heavily on the enthusiasm and participation of the open-source community. We need your help so please dive in! There are many ways to help:

--- a/content/es/docs/getting-started/_index.md
+++ b/content/es/docs/getting-started/_index.md
@@ -4,8 +4,6 @@ linkTitle: "Comenzando"
 weight: 2
 description: >
   ¿Cómo ponerse en marcha rápidamente con Jenkins X?
-aliases:
-  - /getting-started
 ---
 
 La forma más sencilla de comenzar es a través de los [Tutoriales de Google Cloud](/es/docs/managing-jx/tutorials/google-hosted/).

--- a/content/es/docs/getting-started/demos-talks-posts/_index.md
+++ b/content/es/docs/getting-started/demos-talks-posts/_index.md
@@ -1,8 +1,6 @@
 ---
 title: "Demos, charlas y artículos"
 weight: 5
-aliases:
-  - /demos/
 description: >
   Una lista de demostraciones, charlas y publicaciones útiles para continuar en su viaje de inicio.
 ---

--- a/content/es/docs/getting-started/demos-talks-posts/create_cluster_gke.md
+++ b/content/es/docs/getting-started/demos-talks-posts/create_cluster_gke.md
@@ -3,8 +3,6 @@ title: Crear un clúster en GKE
 linktitle: Crear un clúster en GKE
 description: ¿Cómo crear un clúster de Kubernetes en GKE e instalar Jenkins X?
 weight: 40
-aliases:
-  - /demos/create_cluster_gke
 ---
 
 Este [demo](https://www.youtube.com/watch?v=r8-J9Qg-p9U) utiliza el comando [jx create cluster gke](/commands/jx_create_cluster_gke) para [crear un nuevo clúster de Kubernetes](/docs/getting-started/setup/create-cluster/):

--- a/content/es/docs/getting-started/demos-talks-posts/create_spring.md
+++ b/content/es/docs/getting-started/demos-talks-posts/create_spring.md
@@ -3,8 +3,6 @@ title: Crear Aplicación Spring
 linktitle: Crear Aplicación Spring
 description: Cómo crear una nueva aplicación Spring Boot con CI/CD y Promociones GitOps
 weight: 50
-aliases:
-  - /developing/create-spring
 ---
 
 Este [demo](https://www.youtube.com/watch?v=kPes3rvT1UM) utiliza el comando [jx create spring](/commands/jx_create_spring) para [crear una aplicación Spring Boot con pipelines CI/CD](/developing/create-spring) y [Promociones GitOps](/es/docs/concepts/features/#promoción):

--- a/content/es/docs/getting-started/promotion/_index.md
+++ b/content/es/docs/getting-started/promotion/_index.md
@@ -3,8 +3,6 @@ title: Promoción y Entornos
 linktitle: Promoción y Entornos
 description: Promueva las nuevas versiones de su aplicación hacia los entornos
 weight: 4
-aliases:
-  - /developing/promote/
 ---
 
 Los Pipelines de Entrega Continua de Jenkins X automatizan la [promoción](/es/docs/concepts/features/#promoción) de cambio de versiones a través de cada [Entorno](/es/docs/concepts/features/#entornos). Cada Entorno se encuentra configurado con la propiedad _estrategia de promoción_ en `Auto`. La configuración pre-establecida para los entornos es:

--- a/content/es/docs/getting-started/setup/boot/_index.md
+++ b/content/es/docs/getting-started/setup/boot/_index.md
@@ -5,9 +5,6 @@ description: Instalar, configurar y actualizar Jenkins X mediante GitOps y Jenki
 categories: [getting started]
 keywords: [install]
 weight: 10
-aliases:
-  - /getting-started/boot
-  - /docs/reference/boot
 ---
 
 ## Resumen

--- a/content/es/docs/getting-started/setup/create-cluster/_index.md
+++ b/content/es/docs/getting-started/setup/create-cluster/_index.md
@@ -5,8 +5,6 @@ description: ¿Como crear un clúster de Kubernetes?
 categories: [getting started]
 keywords: [cluster]
 weight: 1
-aliases:
-  - /getting-started/create-cluster
 ---
 
 Jenkins X necesita que exista un clúster de Kubernetes para que pueda instalarse mediante el [jx boot](/docs/getting-started/setup/boot/).

--- a/content/es/docs/getting-started/setup/install/_index.md
+++ b/content/es/docs/getting-started/setup/install/_index.md
@@ -4,8 +4,6 @@ linktitle: Instalar jx
 description: ¿Cómo instalar el binario jx en tu máquina?
 weight: 5
 keywords: [instalar]
-aliases:
-  - /getting-started/install
 ---
 
 Elija las instrucciones más adecuadas para su sistema operativo:

--- a/content/es/docs/managing-jx/common-tasks/access-control.md
+++ b/content/es/docs/managing-jx/common-tasks/access-control.md
@@ -1,7 +1,6 @@
 ---
 title: Control de Acceso
 linktitle: Control de Acceso
-aliases: [/rbac/]
 description: Gestionar el Control de Acceso
 weight: 10
 ---

--- a/content/es/docs/managing-jx/faq/_index.md
+++ b/content/es/docs/managing-jx/faq/_index.md
@@ -3,8 +3,6 @@ title: FAQ
 linktitle: FAQ
 description: Preguntas sobre cómo gestionar Jenkins X
 weight: 60
-aliases:
-  - /faq/setup/
 ---
 
 ## ¿Cómo agrego un usuario a mi instalación de Jenkins X?

--- a/content/es/docs/managing-jx/faq/boot.md
+++ b/content/es/docs/managing-jx/faq/boot.md
@@ -3,8 +3,6 @@ title: Preguntas sobre Boot
 linktitle: Preguntas sobre Boot
 description: Preguntas sobre cómo utilizar 'jx boot'
 weight: 20
-aliases:
-  - /faq/issues/
 ---
 
 Para ampliar los detalles vea cómo utilizar [jx boot](/es/docs/getting-started/setup/boot/).

--- a/content/es/docs/managing-jx/faq/issues.md
+++ b/content/es/docs/managing-jx/faq/issues.md
@@ -3,8 +3,6 @@ title: Problemas comunes
 linktitle: Problemas comunes
 description: Preguntas sobre problemas comunes configurando Jenkins X.
 weight: 50
-aliases:
-  - /faq/issues/
 ---
 
 Hemos tratado de recopilar problemas comunes aquí con soluciones alternativas. Si su problema no aparece en esta lista, [infórmenos](https://github.com/jenkins-x/jx/issues/new).


### PR DESCRIPTION
@mmorejon just FYI...it seems Hugo got confused about which page the aliases were pointing to, so some external links that was supposed to link to an english article got the spanish one instead :) 