### PR TITLE
fix: Add redirect from old TLS URL to boot docs

### DIFF
--- a/content/en/docs/getting-started/setup/boot/_index.md
+++ b/content/en/docs/getting-started/setup/boot/_index.md
@@ -11,6 +11,7 @@ weight: 10
 aliases:
   - /getting-started/boot
   - /docs/reference/boot
+  - /architecture/tls
 ---
 
 


### PR DESCRIPTION
Ideally, we'd be redirecting to the `#ingress` anchor, but I can't
find a way to do that. If anyone has a solution, I'd love to see it. =)

fixes https://github.com/jenkins-x/jx/issues/6192

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>