### PR TITLE
docs: hide instructions for Cloud Shell

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -3,24 +3,24 @@ title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 2
 description: >
-  How to get quickly up and running with Jenkins X?
+  How to get quickly up and running with Jenkins X
 aliases:
   - /getting-started
 ---
 
-### Try out Jenkins X quickly
+<!-- ### Try out Jenkins X quickly
 
-The simplest way to get started is via the [Google Cloud Tutorials](/docs/managing-jx/tutorials/google-hosted/).
+The simplest way to get started is via the [Google Cloud Tutorials](/docs/managing-jx/tutorials/google-hosted/). -->
 
 ### Get setup locally
 
-Otherwise first you will need to [get the jx command line tool](/docs/getting-started/setup/install/) locally on your machine.
+First you will need to [get the jx command line tool](/docs/getting-started/setup/install/) locally on your machine.
 
-You can use the [jx command line](/commands/jx/#jx) to [create a new Kubernetes cluster](/docs/getting-started/setup/create-cluster/) with Jenkins X installed automatically.
+Then you can use the [jx command line](/commands/jx/#jx) to [create a new Kubernetes cluster](/docs/getting-started/setup/create-cluster/) with Jenkins X installed automatically.
 
 If you already have a Kubernetes cluster, then [install Jenkins X on your Kubernetes cluster with Jenkins X Boot](/docs/getting-started/setup/boot/).
 
-### Once you have Jenkins X setup and running
+### Once you have Jenkins X set up and running
 
 When you have a Kubernetes cluster with Jenkins X installed, check out [your next steps](/docs/getting-started/next/).
 

--- a/content/en/docs/getting-started/setup/install/_index.md
+++ b/content/en/docs/getting-started/setup/install/_index.md
@@ -117,7 +117,7 @@ choco upgrade jenkins-x
   scoop update jx
   ```
 
-## Google Cloud Platform (GCP)
+<!-- ## Google Cloud Platform (GCP)
 
 {{% alert %}}
 It is highly recommended that you use Google Chrome browser with
@@ -152,11 +152,11 @@ sudo mv jx /usr/local/bin
 jx version
 ```
 
-Once you have the `jx` binary installed you can then [configure a Jenkins X cluster on Google Kubernetes Engine](/getting-started/create-cluster/).
+Once you have the `jx` binary installed you can then [configure a Jenkins X cluster on Google Kubernetes Engine](/getting-started/create-cluster/). -->
 
 ## Other platforms
 
-[download the binary](https://github.com/jenkins-x/jx/releases) for `jx` and add it to your `$PATH`
+[Download the binary](https://github.com/jenkins-x/jx/releases) for `jx` and add it to your `$PATH`
 
 Or you can try [build it yourself](https://github.com/jenkins-x/jx/blob/master/docs/contributing/hacking.md). Though if build it yourself please be careful to remove any older `jx` binary so your local build is found first on the `$PATH` :)
 

--- a/content/en/docs/managing-jx/tutorials/google-hosted.md
+++ b/content/en/docs/managing-jx/tutorials/google-hosted.md
@@ -1,6 +1,7 @@
 ---
 title: Google Cloud Hosted Tutorials
 linktitle: Google Cloud Tutorials
+draft: true
 description: Tutorials using Google Kubernetes Engine & Cloud Shell
 weight: 10
 ---


### PR DESCRIPTION
Currently, due to a conflict in git versions, the `jx` binary is not compatible with GCP Cloud Shell. Therefore, hiding the instructions, tutorials, and references to using GCP Cloud Shell. 
In the future, when this conflict is fixed, then the tutorials may be helpful again.