### PR TITLE
chore: adding references to cloudbees saas + UI

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -8,8 +8,11 @@ aliases:
   - /getting-started
 ---
 
-<!-- ### Try out Jenkins X quickly
+### Try out Jenkins X quickly
 
+If you're looking to take Jenkins X for a spin (or not interested in running it yourself) the quickest way to get up and running, is using the [CloudBees CI-CD powered by Jenkins X](https://www.cloudbees.com/products/cloudbees-ci-cd/overview) which is a SaaS running on Jenkins X.
+
+<!--
 The simplest way to get started is via the [Google Cloud Tutorials](/docs/managing-jx/tutorials/google-hosted/). -->
 
 ### Get setup locally

--- a/content/en/docs/getting-started/next.md
+++ b/content/en/docs/getting-started/next.md
@@ -14,9 +14,12 @@ So whats next?
 
 Well the [Using Jenkins X](/docs/using-jx/) section contains the next steps you may want to try out, such as
 
-* [create a new Spring Boot application and import it into Jenkins X](/docs/using-jx/common-tasks/create-spring/) 
+* [create a new Spring Boot application and import it into Jenkins X](/docs/using-jx/common-tasks/create-spring/)
 * [create a new quickstart and import it into Jenkins X](/docs/getting-started/first-project/create-quickstart/)
 * [import existing source code into Jenkins X](/docs/using-jx/creating/import/)
 * [browsing](/docs/using-jx/developing/browsing/) for browsing pipelines, builds, apps and activity
 
 You may also want to check out the [various demonstrations of what you can do with Jenkins X](/demos/)
+
+If you're looking for a UI, there is one available for the [CloudBees Jenkins X Distribution](https://www.cloudbees.com/products/cloudbees-jenkins-x-distribution/overview). It should normally work on OSS Jenkins X as well, though CloudBees won't support it unless you're also using their distribution. You can read more about it here: [Using the CloudBees Jenkins X Distribution user interface
+](https://docs.cloudbees.com/docs/cloudbees-jenkins-x-distribution/latest/user-interface/)

--- a/content/en/docs/getting-started/setup/boot/_index.md
+++ b/content/en/docs/getting-started/setup/boot/_index.md
@@ -332,7 +332,7 @@ webhook: lighthouse
 
 ## Repository
 
-Jenkins X lets you configure different artifact repositories. We use artifact repositories to: 
+Jenkins X lets you configure different artifact repositories. We use artifact repositories to:
 
 * store artifacts from some kinds of build (e.g. Java builds tend to deploy jars, `pom.xml` files and tarballs)
 * act as a Maven proxy to cache maven dependencies when using java/maven builds
@@ -341,20 +341,20 @@ Jenkins X lets you configure different artifact repositories. We use artifact re
 ### Nexus
 
 By default if you don't make any explicit configuration then Jenkins X uses:
- 
-* [Nexus](https://www.sonatype.com/nexus-repository-oss) as an artifact repository to store artifacts (e.g. Java jars, `pom.xml` files, tarballs or npm modules etc) 
+
+* [Nexus](https://www.sonatype.com/nexus-repository-oss) as an artifact repository to store artifacts (e.g. Java jars, `pom.xml` files, tarballs or npm modules etc)
 * [ChartMuseum](https://chartmuseum.com/) as a repository of charts
 
 You can explicitly configure nexus via the following `jx-requirements.yml` file:
 
 ```yaml
 repository: nexus
-```         
+```
 
 ### Bucketrepo
 
-The [bucketrepo](https://github.com/jenkins-x/bucketrepo) chart is a small footprint microservice that is an alternative to both [Nexus](https://www.sonatype.com/nexus-repository-oss) and [Chartmusem](https://chartmuseum.com/) which can: 
- 
+The [bucketrepo](https://github.com/jenkins-x/bucketrepo) chart is a small footprint microservice that is an alternative to both [Nexus](https://www.sonatype.com/nexus-repository-oss) and [Chartmusem](https://chartmuseum.com/) which can:
+
 * act as a Maven proxy to cache maven dependencies when using java/maven builds
 * act as an artifact repository (e.g. to deploy maven artifacts)
 * implement a chart repository for releasing helm charts
@@ -363,9 +363,9 @@ To enable `bucketrepo` use the following `jx-requirements.yml` file:
 
 ```yaml
 repository: bucketrepo
-```   
+```
 
-By default the local file system in the bucket repo is used to store artifacts. 
+By default the local file system in the bucket repo is used to store artifacts.
 
 To enable cloud storage for artifacts in `bucketrepo` you need to enable the `storage.repository` configuration in which case a cloud bucket is used instead. See the [storage section for more details](#storage).
 
@@ -376,7 +376,7 @@ If you want to disable the artifact repository (nexus) but still use ChartMuseum
 
 ```yaml
 repository: none
-```         
+```
 
 Note that without using an artifact repository you will not be able to deploy Maven artifacts; though [ChartMuseum](https://chartmuseum.com/) will still be used as a repository of charts
 
@@ -556,3 +556,8 @@ velero:
 ```
 
 Using whatever your cloud providers bucket URLs are. For more background, check out the [storage guide](/docs/managing-jx/common-tasks/storage/)
+
+## User Interface
+
+If you're looking for a UI, there is one available for the [CloudBees Jenkins X Distribution](https://www.cloudbees.com/products/cloudbees-jenkins-x-distribution/overview). It should normally work on OSS Jenkins X as well, though CloudBees won't support it unless you're also using their distribution. You can read more about it here: [Using the CloudBees Jenkins X Distribution user interface
+](https://docs.cloudbees.com/docs/cloudbees-jenkins-x-distribution/latest/user-interface/)

--- a/content/en/docs/managing-jx/faq/_index.md
+++ b/content/en/docs/managing-jx/faq/_index.md
@@ -171,4 +171,8 @@ We've left out the other values of `expose:` and `config:` for brevity - the imp
 
 Whenever you modify the git repository for an environment the GitOps pipeline will run to update your Ingress resources to match your `UrlTemplate`.
 
+## Is there a UI available for Jenkins X?
+
+There is one available for the [CloudBees Jenkins X Distribution](https://www.cloudbees.com/products/cloudbees-jenkins-x-distribution/overview). It should normally work on OSS Jenkins X as well, though CloudBees won't support it unless you're also using their distribution. You can read more about it here: [Using the CloudBees Jenkins X Distribution user interface
+](https://docs.cloudbees.com/docs/cloudbees-jenkins-x-distribution/latest/user-interface/)
 


### PR DESCRIPTION
the SaaS would be the simplest way to try out jx, so it makes sense to let people know about it

similarly, the UI should theoretically "just work" for OSS instances, so if people are interested in using it, it'd make sense to make them aware it exists. It's free to use but not OSS