### PR TITLE
fix: Change docs to refer to correct jx-requirements.yml filename

### DIFF
--- a/content/en/docs/contributing/code/contribute_dns.md
+++ b/content/en/docs/contributing/code/contribute_dns.md
@@ -36,7 +36,7 @@ this process again.
 6. Click `Create`
 7. Tell Jenkins X about the name.
   * If you are using `jx install --external-dns` then paste `<unique name>.<your username>.jenkins-x.rocks` into the prompt where you paused earlier
-  * If you are using `jx boot` then edit `jx-requirements.yaml`, and update the `domain` field (in `ingress`)
+  * If you are using `jx boot` then edit `jx-requirements.yml`, and update the `domain` field (in `ingress`)
     to `<unique name>.<your username>.jenkins-x.rocks` and run `jx boot`
 
 ## Without External DNS on Google Cloud Platform
@@ -54,7 +54,7 @@ Once you have access, you can use the `Add record set` button to add entries or 
   * If you used `jx install` then you **must** configure this during install. When you are prompted if you want to use
     the default `.nip.io` domain copy the IP. You **must** now wait until your domain name is ready.
   * If you used jx boot then you can do this at any time. The domain name is present in the domain name and can be found
-    in `jx-requirements.yaml`. Copy the IP.
+    in `jx-requirements.yml`. Copy the IP.
 3. Use the default values for `Resource Record Type` (`A`), `TTL` (`5`) and `TTL Unit` (`minutes`).
 4. Paste the IP address you found above into the `IPv4 Address` field
 5. Click `Create`
@@ -63,7 +63,7 @@ Once you have access, you can use the `Add record set` button to add entries or 
 you found above the DNS has propagated. If you are using a Mac `watch` can be installed using `brew install watch`
 7. Tell Jenkins X about the name.
   * If you are using `jx install` then paste `<unique name>.<your username>.jenkins-x.rocks` into the prompt where you paused earlier
-  * If you are using `jx boot` then edit `jx-requirements.yaml`, and update the `domain` field (in `ingress`)
+  * If you are using `jx boot` then edit `jx-requirements.yml`, and update the `domain` field (in `ingress`)
     to `<unique name>.<your username>.jenkins-x.rocks` and run `jx boot`
 
 > If you prefer to use the gcloud CLI you can find instructions for usage on the "Create record set" screen.

--- a/content/en/docs/reference/api.md
+++ b/content/en/docs/reference/api.md
@@ -9531,7 +9531,7 @@ string
 </em>
 </td>
 <td>
-<p>BootRequirements is a marshaled string of the jx-requirements.yaml used in the most recent run for this cluster</p>
+<p>BootRequirements is a marshaled string of the jx-requirements.yml used in the most recent run for this cluster</p>
 </td>
 </tr>
 </tbody>

--- a/content/en/docs/reference/commands/jx_boot.md
+++ b/content/en/docs/reference/commands/jx_boot.md
@@ -44,8 +44,8 @@ jx boot [flags]
   -h, --help                   help for boot
   -r, --requirements string    requirements file which will overwrite the default requirements file
   -s, --start-step string      the step in the pipeline to start from
-      --versions-ref string    the bootstrap ref for the versions repo. Once the boot config is cloned, the repo will be then read from the jx-requirements.yaml (default "master")
-      --versions-repo string   the bootstrap URL for the versions repo. Once the boot config is cloned, the repo will be then read from the jx-requirements.yaml (default "https://github.com/jenkins-x/jenkins-x-versions.git")
+      --versions-ref string    the bootstrap ref for the versions repo. Once the boot config is cloned, the repo will be then read from the jx-requirements.yml (default "master")
+      --versions-repo string   the bootstrap URL for the versions repo. Once the boot config is cloned, the repo will be then read from the jx-requirements.yml (default "https://github.com/jenkins-x/jenkins-x-versions.git")
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/reference/components/vault.md
+++ b/content/en/docs/reference/components/vault.md
@@ -121,7 +121,7 @@ For a secure Jenkins X installation, you must
 enable TLS when interacting with the vault service. To configure TLS,
 you must first configure Zone DNS settings within Google Cloud Platform,
 and then configure external DNS settings for Ingress and TLS in the
-`jx-requirements.yaml` configuration file.
+`jx-requirements.yml` configuration file.
 
 ## Configuring Google Cloud DNS
 
@@ -202,11 +202,11 @@ Next up is configuring GCP:
 
 Finally, configure Jenkins X for the new domain names:
 
-1. Edit the `jx-requirements.yaml` file and update the `domain` field (in `ingress`) to your domain name, for example `cluster1.acmecorp.example`
+1. Edit the `jx-requirements.yml` file and update the `domain` field (in `ingress`) to your domain name, for example `cluster1.acmecorp.example`
 
 1. In the *tls* setting, enable TLS with `enabled: true`
 
-The resulting `jx-requirements.yaml` entries for these settings should look similar to the example below:
+The resulting `jx-requirements.yml` entries for these settings should look similar to the example below:
 
 ```yaml
 gitops: true

--- a/content/en/docs/using-jx/faq/_index.md
+++ b/content/en/docs/using-jx/faq/_index.md
@@ -239,11 +239,13 @@ See how to [add a custom step to your pipeline](/docs/concepts/jenkins-x-pipelin
 
 ### Staging/Production
 
-By default, [enabling Vault](/docs/getting-started/setup/boot/#vault) via `jx boot`'s `jx-requirements.yaml` will only activate it in your pipeline and preview environments, not in staging and production. To also activate it in those environments, simply add a `jx-requirements.yaml` file to the root of their repo, with at least the following content:
+By default, [enabling Vault](/docs/getting-started/setup/boot/#vault) via `jx boot`'s `jx-requirements.yml` will only activate it in your pipeline and preview environments, not in staging and production. To also activate it in those environments, simply add a `jx-requirements.yml` file to the root of their repo, with at least the following content:
 
 ```yaml
 secretStorage: vault
 ```
+
+Note that the file **must** be named with `.yml`, not `.yaml`, or else the requirements loader cannot load the proper file.
 
 Then, assuming you have a secret in Vault with path `secret/path/to/mysecret` containing key `password`, you can inject it into service `myapp` (for instance, as a `PASSWORD` environment variable) by adding the following to your staging repo's `/env/values.yaml`:
 

--- a/content/es/docs/reference/components/vault.md
+++ b/content/es/docs/reference/components/vault.md
@@ -78,7 +78,7 @@ safe set /secret/my-cluster-name/creds/my-secret json=@myfile.txt
 # Configurar DNS y TLS para Vault
 
 Para una instalación segura de Jenkins X, debe habilite TLS cuando interactúe con el servicio de almacenamiento. Para configurar TLS, primero debe configurar los ajustes de DNS de Zona en Google Cloud Platform, y luego configure los ajustes de DNS externos para el `Ingress` y TLS en el
-fichero de configuración ``jx-requirements.yaml`.
+fichero de configuración ``jx-requirements.yml`.
 
 ## Configurar Google Cloud DNS
 
@@ -139,11 +139,11 @@ El siguiente paso es configurar GCP:
 
 Finalmente, configure Jenkins X para los nuevos nombres de dominio:
 
-1. Edite el fichero `jx-requirements.yaml` y actualice el campo `dominio` (en `Ingress`) a su nombre de dominio, por ejemplo `cluster1.acmecorp.example`.
+1. Edite el fichero `jx-requirements.yml` y actualice el campo `dominio` (en `Ingress`) a su nombre de dominio, por ejemplo `cluster1.acmecorp.example`.
 
 2. En la configuración *tls*, habilite TLS con `enabled: true`.
 
-El fichero `jx-requirements.yaml` quedaría de la siguiente forma si utilizamos las configuraciones mencionadas:
+El fichero `jx-requirements.yml` quedaría de la siguiente forma si utilizamos las configuraciones mencionadas:
 
 ```yaml
 gitops: true

--- a/content/es/docs/using-jx/faq/_index.md
+++ b/content/es/docs/using-jx/faq/_index.md
@@ -236,7 +236,7 @@ Vea cómo [agregar un paso personalizado a su pipeline](/docs/concepts/jenkins-x
 
 ### Staging/Production
 
-De forma predeterminada, [habilitar Vault](/docs/getting-started/setup/boot/#vault) a través de los `jx-requirements.yaml` de `jx boot` solo lo activará en sus entornos de pipeline y vista previa, no en staging y producción. Para activarlo también en esos entornos, simplemente agregue un archivo `jx-requirements.yaml` a la raíz de su repositorio, con al menos el siguiente contenido:
+De forma predeterminada, [habilitar Vault](/docs/getting-started/setup/boot/#vault) a través de los `jx-requirements.yml` de `jx boot` solo lo activará en sus entornos de pipeline y vista previa, no en staging y producción. Para activarlo también en esos entornos, simplemente agregue un archivo `jx-requirements.yml` a la raíz de su repositorio, con al menos el siguiente contenido:
 
 ```yaml
 secretStorage: vault

--- a/static/apidocs/index.html
+++ b/static/apidocs/index.html
@@ -5260,7 +5260,7 @@ The contents of the target Secret&#39;s Data field will be presented in a volume
 <TR><TD><CODE>appPrefixes</CODE><BR /><I>string array</I></TD><TD>AppsPrefixes is the list of prefixes for appNames</TD></TR>
 <TR><TD><CODE>appsRepository</CODE><BR /><I>string</I></TD><TD></TD></TR>
 <TR><TD><CODE>askOnCreate</CODE><BR /><I>boolean</I></TD><TD></TD></TR>
-<TR><TD><CODE>bootRequirements</CODE><BR /><I>string</I></TD><TD>BootRequirements is a marshaled string of the jx-requirements.yaml used in the most recent run for this cluster</TD></TR>
+<TR><TD><CODE>bootRequirements</CODE><BR /><I>string</I></TD><TD>BootRequirements is a marshaled string of the jx-requirements.yml used in the most recent run for this cluster</TD></TR>
 <TR><TD><CODE>branchPatterns</CODE><BR /><I>string</I></TD><TD></TD></TR>
 <TR><TD><CODE>buildPackName</CODE><BR /><I>string</I></TD><TD></TD></TR>
 <TR><TD><CODE>buildPackRef</CODE><BR /><I>string</I></TD><TD></TD></TR>


### PR DESCRIPTION
Add note explaining why it must be .yml and not .yaml

Helps explain [#5141](https://github.com/jenkins-x/jx/issues/5141) and clear up confusion with documentation

The requirements loader in the jx cmd code will only load jx-requirements.yml and NOT jx-requirements.yaml. I think that should also be changed to allow for both extensions, however the easy fix right now is to clear up the confusion with the docs first.