### PR TITLE
docs: brew, use one-liner where brew install does it all

### DIFF
--- a/content/en/docs/getting-started/setup/install/_index.md
+++ b/content/en/docs/getting-started/setup/install/_index.md
@@ -17,8 +17,7 @@ Pick the most suitable instructions for your operating system:
     On a Mac you can use [brew](https://brew.sh/):
 
 ```sh
-brew tap jenkins-x/jx
-brew install jx
+brew install jenkins-x/jx/jx
 ```
 
     Alternatively, to install Jenkins X on macOS without brew, download the `.tar` file, and unarchive it in a directory where you can run the `jx` command.

--- a/content/es/docs/getting-started/setup/install/_index.md
+++ b/content/es/docs/getting-started/setup/install/_index.md
@@ -13,8 +13,7 @@ Elija las instrucciones más adecuadas para su sistema operativo:
 En una Mac puedes utilizar [brew](https://brew.sh/):
 
 ```sh
-brew tap jenkins-x/jx
-brew install jx
+brew install jenkins-x/jx/jx
 ```
 
 Para instalar Jenkins X en macOS sin utilizar brew debes descargar el fichero `.tar` y descomprimirlo en el directorio donde puedas ejecutar el comando `jx`.

--- a/content/zh/docs/getting-started/setup/install/_index.md
+++ b/content/zh/docs/getting-started/setup/install/_index.md
@@ -17,8 +17,7 @@ weight: 2
 在 Mac 上你可以使用 [brew](https://brew.sh/)：
 
 ```sh
-brew tap jenkins-x/jx
-brew install jx
+brew install jenkins-x/jx/jx
 ```
 
 或者，如果您尚未安装 [brew](https://brew.sh/) ，并且喜欢手动安装的话，请执行如下指令安装:


### PR DESCRIPTION
From https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap#installing:

> ### Installing
> If it’s on GitHub, users can install any of your formulae with `brew install user/repo/formula`. Homebrew will automatically add your `github.com/user/homebrew-repo` tap before installing the formula. `user/repo/formula` points to the `github.com/user/homebrew-repo/**/formula.rb` file here.
>
> If they want to get your tap without installing any formula at the same time, users can add it with the `brew tap user/repo` command.

Can't tell when that was introduced, but it makes the `brew` installation a one-liner 😁