### PR TITLE
docs: Update multi-cluster.md: add warning when using older helm version to install the environment controller

### DIFF
--- a/content/en/docs/reference/multi-cluster.md
+++ b/content/en/docs/reference/multi-cluster.md
@@ -76,6 +76,16 @@ The installer needs a user + API token for the git repository which it will prom
 
 If you prefer you can install the helm chart `jenkins-x/environment-controller` directly with helm by specifying the [required values from the values.yaml file](https://github.com/jenkins-x-charts/environment-controller/blob/master/environment-controller/values.yaml#L3-L19)
 
+**Fetch issues during installation**
+
+You might run into the issue, that you cannot deploy the envirnment controller, since helm is unable to download the chart file. This might be due to the fact, that older helm versions have issues with a missing trailing slash on the repo url. See [helm/issues/4954](https://github.com/helm/helm/issues/4954)
+
+```
+helm fetch -d /tmp/helm-template-workdir-742964675/jxet/chartFiles --untar environment-controller --repo https://storage.googleapis.com/chartmuseum.jenkins-x.io --version
+Error: Failed to fetch https://storage.googleapis.com/charts/environment-controller-0.0.617.tgz : 403 Forbidden
+```
+
+In that case, upgrading your helm version might help.
 
 ## Installing Ingress Controller
 


### PR DESCRIPTION
**Summary: Yesterday i struggled a lot while installing the environment controller.
In order to save others some time, i'd like to add a small hint to the documentation.**

This was found yesterday in the discussion with @jstrachan and upgrading helm to v2.16.1 did solve the download issue.

The command that raised the issue was:
```
jx create addon envctl -s https://gitlab.server.example.com/environment-production.git --docker-registry gitlab.server.example.com:4567 --cluster-rbac true --user jenkinsx --token XXX --version 0.0.617
```

This led to the error:
```
error: failed to run 'helm fetch -d /tmp/helm-template-workdir-635696494/jxet/chartFiles --untar environment-controller --repo https://storage.googleapis.com/chartmuseum.jenkins-x.io --version 0.0.617' command in directory '', output: 'Error: Failed to fetch https://storage.googleapis.com/charts/environment-controller-0.0.617.tgz : 403 Forbidden'
```