### PR TITLE
docs: add jx step stash information

### DIFF
--- a/content/en/docs/managing-jx/common-tasks/storage.md
+++ b/content/en/docs/managing-jx/common-tasks/storage.md
@@ -66,7 +66,12 @@ jx step stash -c coverage -p "build/coverage/*" --bucket-url s3://my-aws-bucket
 
 * specify the `classifier` via `-c` such as for `tests` or `coverage` etc.
 * specify the files to collect via `-p` which supports wildcards like `*`. files which will be stored with the relative directory path
-* if you want to remove a direectory prefix from the stashed files, like `target/reports` you can use `--basedir` to specify the directory to create relative file names from
+* if you want to remove a directory prefix from the stashed files, like `target/reports` you can use `--basedir` to specify the directory to create relative file names from
+
+{{% pageinfo %}}
+**NOTE** Be aware that you have to run `jx step stash` inside your git repository,
+therefore `dir:` should be set to `/workspace/source` in your stash step.
+{{% /pageinfo %}}
 
 By default [jx step stash](/commands/jx_step_stash/) will use your team's configured location for the classification you give. If you wish you can override the location for a stash using `--git-url` or `--bucket-url`
 

--- a/content/en/docs/reference/commands/jx_step_stash.md
+++ b/content/en/docs/reference/commands/jx_step_stash.md
@@ -6,7 +6,7 @@ url: /commands/jx_step_stash/
 ---
 ## jx step stash
 
-Stashes local files generated as part of a pipeline into long term storage
+Stashes local files generated as part of a pipeline into long term storage.
 
 ### Synopsis
 
@@ -14,12 +14,18 @@ This pipeline step stashes the specified files from the build into some stable s
   
 Currently Jenkins X supports storing files into a branch of a git repository or in cloud blob storage like S3, GCS, Azure blobs etc. 
 
-When using Cloud Storage we use URLs like 's3://nameOfBucket' on AWS, 'gs://anotherBucket' on GCP or on Azure 'azblob://thatBucket' 
+When using Cloud Storage we use URLs like `s3://nameOfBucket` on AWS, `gs://anotherBucket` on GCP or on Azure `azblob://thatBucket`.
+
+
+{{% pageinfo %}}
+**NOTE** Be aware that you have to run `jx step stash` inside your git repository,
+therefore `dir:` should be set to `/workspace/source` in your stash step.
+{{% /pageinfo %}}
 
 See Also: 
 
-  * jx step unstash : https://jenkins-x.io/commands/jx_step_unstash  
-  * jx edit storage : https://jenkins-x.io/commands/jx_edit_storage
+  * [jx step unstash](https://jenkins-x.io/commands/jx_step_unstash)
+  * [jx edit storage](https://jenkins-x.io/commands/jx_edit_storage)
 
 ```
 jx step stash [flags]


### PR DESCRIPTION
During testing `jx step stash`  I realized that you have to run `jx step stash` inside the source git repository, otherwise it will always result in a git error.
Since this seems to be very important for now I added it to the docs.