### PR TITLE
docs: add new categories with jx edit storage

### DIFF
--- a/content/en/docs/managing-jx/common-tasks/storage.md
+++ b/content/en/docs/managing-jx/common-tasks/storage.md
@@ -36,7 +36,6 @@ You can also use the special classification `default` which is used if you don't
 
 If you are using [jx boot](/docs/getting-started/setup/boot/) to install and configure your setup then modify your `jx-requirements.yml` file to configure storage as described in the [boot storage documentation](/docs/getting-started/setup/boot/#storage)
 
-
 Otherwise to configure the storage location for a classification and team you use the [jx edit storage](/commands/jx_edit_storage/)
 
 e.g.
@@ -47,6 +46,9 @@ jx edit storage -c tests --bucket-url s3://myExistingBucketName
 
 # Configure the git URL and branch of where to store logs
 jx edit storage -c logs --git-url https://github.com/myorg/mylogs.git --git-branch cheese
+
+# Configure your own category
+jx edit storage -c <new-category> --bucket-url gs://myExistingBucketName
 ```
 
 You can view your teams storage settings via [jx get storage](/commands/jx_get_storage/)

--- a/content/en/docs/reference/commands/jx_edit_storage.md
+++ b/content/en/docs/reference/commands/jx_edit_storage.md
@@ -6,22 +6,21 @@ url: /commands/jx_edit_storage/
 ---
 ## jx edit storage
 
-Configures the storage location for stashing files or storing build logs for your team
+Configures the storage location for stashing files or storing build logs for your team.
 
 ### Synopsis
 
-Configures the storage location used by your team to stashing files or storing build logs.
   
-      If you don't specify any specific storage for a classifier it will try the classifier 'default'. If there is still no configuration then it will default to the git repository for a project.'
+    If you don't specify any specific storage for a classifier it will try the classifier 'default'. If there is still no configuration then it will default to the git repository for a project.'
   
 Currently Jenkins X supports storing files into a branch of a git repository or in cloud blob storage like S3, GCS, Azure blobs etc. 
 
-When using Cloud Storage we use URLs like 's3://nameOfBucket' on AWS, 'gs://anotherBucket' on GCP or on Azure 'azblob://thatBucket' 
+When using Cloud Storage we use URLs like `s3://nameOfBucket` on AWS,  `gs://anotherBucket` on GCP or on Azure `azblob://thatBucket`. 
 
 See Also: 
 
-  * jx step stash : https://jenkins-x.io/commands/jx_step_stash  
-  * jx get storage : https://jenkins-x.io/commands/jx_get_storage
+  * [jx step stash](https://jenkins-x.io/commands/jx_step_stash)
+  * [jx get storage](https://jenkins-x.io/commands/jx_get_storage)
 
 ```
 jx edit storage [flags]
@@ -52,6 +51,10 @@ jx edit storage [flags]
   
   # Creates a new GCS bucket and configures the logs to be stored in it
   jx edit storage -c logs --bucket myBucketName
+
+
+  # Create your own category
+  jx edit storage -c <new-category> --bucket-url gs://myExistingBucketName
 ```
 
 ### Options

--- a/content/en/docs/reference/commands/jx_get_storage.md
+++ b/content/en/docs/reference/commands/jx_get_storage.md
@@ -6,20 +6,18 @@ url: /commands/jx_get_storage/
 ---
 ## jx get storage
 
-Display the storage configuration for different classifications
+Display the storage configuration for different classifications.
 
 ### Synopsis
-
-Display the storage configuration for different classifications.
   
 Currently Jenkins X supports storing files into a branch of a git repository or in cloud blob storage like S3, GCS, Azure blobs etc. 
 
-When using Cloud Storage we use URLs like 's3://nameOfBucket' on AWS, 'gs://anotherBucket' on GCP or on Azure 'azblob://thatBucket' 
+When using Cloud Storage we use URLs like `s3://nameOfBucket` on AWS, `gs://anotherBucket` on GCP or on Azure `azblob://thatBucket`.
 
 See Also: 
 
-  * jx step stash : https://jenkins-x.io/commands/jx_step_stash  
-  * jx edit storage : https://jenkins-x.io/commands/jx_edit_storage
+  * [jx step stash](https://jenkins-x.io/commands/jx_step_stash)
+  * [jx edit storage](https://jenkins-x.io/commands/jx_edit_storage)
 
 ```
 jx get storage [flags]


### PR DESCRIPTION
Previously, I wasn't aware that you could also create new categories with `jx edit storage` as there was no documentation about it, I also improved a few readability related things.