### PR TITLE
chore: update deprecation list

### DIFF
--- a/content/en/docs/reference/commands/deprecation.md
+++ b/content/en/docs/reference/commands/deprecation.md
@@ -14,22 +14,14 @@ description: list of jx commands which have been deprecated
 | Command        | Removal Date   | Replacement  |
 |----------------|----------------|--------------|
 | jx console | Jun 1 2020 | jx ui |
-| jx create post | Feb 1 2020 |  |
 | jx create spring | Mar 1 2020 | jx create project |
-| jx delete extension | Feb 1 2020 |  |
-| jx delete post | Feb 1 2020 |  |
 | jx edit extensionsrepository | Feb 1 2020 |  |
 | jx get post | Feb 1 2020 |  |
 | jx init | Jun 1 2020 | jx boot |
 | jx install | Jun 1 2020 | jx boot |
-| jx step create jenkins | Feb 1 2020 |  |
 | jx step credential | Jun 1 2020 |  |
 | jx step nexus drop | Feb 1 2020 |  |
 | jx step nexus release | Feb 1 2020 |  |
 | jx step post | Feb 1 2020 |  |
-| jx step pre | Feb 1 2020 |  |
-| jx update cluster | Feb 1 2020 | gcloud container cluster upgrade |
-| jx upgrade cluster | Feb 1 2020 | jx boot |
-| jx upgrade extensions | Feb 1 2020 | jx upgrade apps |
 | jx upgrade ingress | Jun 1 2020 | jx boot |
 | jx upgrade platform | Jun 1 2020 | jx upgrade boot |


### PR DESCRIPTION
Some of the commands in the deprecation list have been removed from Jenkins-X and are no longer in there.

fixes #2628 