### PR TITLE
fix: move output outside of module

### DIFF
--- a/content/en/docs/getting-started/setup/create-cluster/eks.md
+++ b/content/en/docs/getting-started/setup/create-cluster/eks.md
@@ -28,16 +28,16 @@ A default Jenkins X ready cluster can be provisioned by creating a _main.tf_ fil
 ```terraform
 module "eks-jx" {
   source  = "jenkins-x/eks-jx/aws"
+}
 
-  output "vault_user_id" {
-    value       = module.eks-jx.vault_user_id
-    description = "The Vault IAM user id"
-  }
+output "vault_user_id" {
+  value       = module.eks-jx.vault_user_id
+  description = "The Vault IAM user id"
+}
 
-  output "vault_user_secret" {
-    value       = module.eks-jx.vault_user_secret
-    description = "The Vault IAM user secret"
-  }
+output "vault_user_secret" {
+  value       = module.eks-jx.vault_user_secret
+  description = "The Vault IAM user secret"
 }
 ```
 


### PR DESCRIPTION
Receive an error when running terraform apply when output is inside of module. Moved it outside of the module block.