### PR TITLE
fix: link color within bootstrap alerts

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -2,6 +2,11 @@
   color: rgb(255, 255, 255);
 }
 
+.alert a{
+  color: #ffffff;
+  text-decoration: underline;
+}
+
 /*!
  * Bootswatch v4.4.1
  * Homepage: https://bootswatch.com
@@ -5630,6 +5635,8 @@
  
  .alert-link {
    font-weight: 700;
+   text-decoration: underline;
+   
  }
  
  .alert-dismissible {


### PR DESCRIPTION
The Bootstrap theme brings colorful alerts, but the links within alerts were not being displayed correctly or were invisible.  Fixes #2685 Closes #2685 