### PR TITLE
chore: adding labs warning to all labs related documentation

### DIFF
--- a/content/en/docs/labs/boot/_index.md
+++ b/content/en/docs/labs/boot/_index.md
@@ -7,7 +7,17 @@ weight: 7
 aliases:
   - /artwork
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 The new version of boot uses Helm 3 and [helmfile](https://github.com/roboll/helmfile) to make a number of [improvements](benefits) over Jenkins X 2.x use of helm 2.
 

--- a/content/en/docs/labs/boot/apps.md
+++ b/content/en/docs/labs/boot/apps.md
@@ -4,7 +4,17 @@ linktitle: Apps framework
 description: Apps framework - coming soon!
 weight: 100
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 The new [helmfile](https://github.com/roboll/helmfile) and helm 3 approach extends the app extension model in Jenkins X.
 

--- a/content/en/docs/labs/boot/background.md
+++ b/content/en/docs/labs/boot/background.md
@@ -4,6 +4,17 @@ linktitle: Background
 description: Background and the enhancement proposal
 weight: 120
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 see the [issue](https://github.com/jenkins-x/jx/issues/6442) and [enhancement proopsal](https://github.com/jenkins-x/enhancements/tree/master/proposals/2)
 

--- a/content/en/docs/labs/boot/benefits.md
+++ b/content/en/docs/labs/boot/benefits.md
@@ -4,7 +4,17 @@ linktitle: Benefits
 description: Benefits of the new helm 3 based boot
 weight: 80
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 * We can use vanilla helm 3 now to install, update or delete charts in any namespace without needing tiller or custom code to manage `helm template`
   * We can avoid all the complexities of the `jx step helm apply` logic using our own helm template generation + post processing logic. We can also move away from boot's use of `{{ .Requirements.foo }}` and `{{ .Parameters.bar }}` expressions

--- a/content/en/docs/labs/boot/comparison.md
+++ b/content/en/docs/labs/boot/comparison.md
@@ -4,7 +4,17 @@ linktitle: Comparison
 description: Comparison of helm 3 + helmfile versus helm 2 with boot
 weight: 90
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 This document outlines the similarities and differences of the helmfile / helm 3 approach for those who are aware of `jx boot` with helm 2.
 

--- a/content/en/docs/labs/boot/faq/_index.md
+++ b/content/en/docs/labs/boot/faq/_index.md
@@ -7,6 +7,17 @@ aliases:
   - /faq/
 ---
 
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 ## How do I list the apps that have been deployed?
 

--- a/content/en/docs/labs/boot/getting-started/_index.md
+++ b/content/en/docs/labs/boot/getting-started/_index.md
@@ -8,3 +8,14 @@ lastmod: 2020-02-21
 weight: 5
 ---
 
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}

--- a/content/en/docs/labs/boot/getting-started/cloud/_index.md
+++ b/content/en/docs/labs/boot/getting-started/cloud/_index.md
@@ -5,6 +5,18 @@ description: Setting up your Kubernetes cluster and associated cloud resources
 weight: 10
 ---
 
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
+
 If you are using Google Cloud and you just want to give Jenkins X a try, we recommend using [gcloud](/docs/labs/boot/getting-started/cloud/gcloud/) to setup your Kubernetes cluster.
 
 If you are setting up a production installation of Jenkins X have a look at our [Terraform](/docs/labs/boot/getting-started/cloud/terraform/) setup.

--- a/content/en/docs/labs/boot/getting-started/cloud/gcloud.md
+++ b/content/en/docs/labs/boot/getting-started/cloud/gcloud.md
@@ -5,6 +5,18 @@ description: Using gcloud to setup google cloud resources
 weight: 10
 ---
 
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
+
 # Prerequisites
 
 Before you begin you need to install [gcloud](https://cloud.google.com/sdk/gcloud)

--- a/content/en/docs/labs/boot/getting-started/cloud/terraform.md
+++ b/content/en/docs/labs/boot/getting-started/cloud/terraform.md
@@ -5,4 +5,16 @@ description: Using terraform to setup your cloud resources
 weight: 20
 ---
 
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
+
 TODO

--- a/content/en/docs/labs/boot/getting-started/config.md
+++ b/content/en/docs/labs/boot/getting-started/config.md
@@ -4,6 +4,17 @@ linktitle: Configuration
 description: Changing your configuration
 weight: 40
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 You can edit the `jx-requirements.yml` file in the git repository that was created in an earlier step for your `dev` environment, to configure various capabilities:
 

--- a/content/en/docs/labs/boot/getting-started/repository.md
+++ b/content/en/docs/labs/boot/getting-started/repository.md
@@ -4,6 +4,17 @@ linktitle: Create Repository
 description: Create a Git repository for your installation
 weight: 20
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 Once you are connected to a Kubernetes cluster you need to create a git repository for your development environment.
 

--- a/content/en/docs/labs/boot/getting-started/run.md
+++ b/content/en/docs/labs/boot/getting-started/run.md
@@ -4,7 +4,17 @@ linktitle: Running Boot
 description: Running Boot to install / upgrade Jenkins X
 weight: 50
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 Once you have [created your git repository](/docs/labs/boot/getting-started/repository/) for your development environment via `jxl boot create` or `jxl boot upgrade` and populated the [secrets](/docs/labs/boot/getting-started/secrets/) as shown above you can run the boot `Job` via:
 

--- a/content/en/docs/labs/boot/getting-started/secrets/_index.md
+++ b/content/en/docs/labs/boot/getting-started/secrets/_index.md
@@ -4,6 +4,17 @@ linktitle: Secrets
 description: Setting up the secrets for your installation
 weight: 30
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 You need to specify a few secret values before you can boot up. 
 

--- a/content/en/docs/labs/boot/getting-started/secrets/vault.md
+++ b/content/en/docs/labs/boot/getting-started/secrets/vault.md
@@ -4,7 +4,17 @@ linktitle: Vault
 description: Using Vault for your Secret storage
 weight: 30
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 To be able to use Vault as the storage engine for your Secrets you need to specify `--secret vault` when [creating your development git repository](/docs/labs/boot/getting-started/repository/) or [configure vault](/docs/labs/boot/getting-started/config/#vault) via `secretStorage: vault` in your `jx-requirements.yml`:
 

--- a/content/en/docs/labs/boot/how-it-works.md
+++ b/content/en/docs/labs/boot/how-it-works.md
@@ -4,6 +4,17 @@ linktitle: How it works
 description: How boot works under the covers
 weight: 130
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 ## How it works
 

--- a/content/en/docs/labs/boot/multi-cluster.md
+++ b/content/en/docs/labs/boot/multi-cluster.md
@@ -4,6 +4,17 @@ linktitle: Multi-Cluster
 description: How to use multiple clusters with helm 3 and helmfile
 weight: 6
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 We recommend using separate clusters for your `Staging` and `Production` environments. This lets you completely isolate your environments which improves security.
 

--- a/content/en/docs/labs/boot/progressive-delivery.md
+++ b/content/en/docs/labs/boot/progressive-delivery.md
@@ -4,6 +4,17 @@ linktitle: Progressive Delivery
 description: How to use progressive delivery with helm 3 and helmfile
 weight: 7
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 Progressive delivery allows you to gradually rollout new versions of your application to an environment using _canaries_ and gradually giving traffic to the new version until you are happy to fully rollover to the new version.
 

--- a/content/en/docs/labs/jenkins/_index.md
+++ b/content/en/docs/labs/jenkins/_index.md
@@ -5,7 +5,17 @@ type: docs
 description: Improved Jenkins and Jenkins X interoperability
 weight: 30
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 The [jxl binary](/docs/labs/jxl/) includes the initial version of the [Trigger Jenkins Proposal](https://github.com/jstrachan/enhancements/blob/jenkins-trigger/proposals/trigger-jenkins/README.md) to improve the interoperability of Jenkins and Jenkins X
 

--- a/content/en/docs/labs/jenkins/getting-started.md
+++ b/content/en/docs/labs/jenkins/getting-started.md
@@ -4,6 +4,17 @@ linktitle: Getting Started
 description: Getting started with Jenkins and Jenkins X interop
 weight: 20
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 Make sure you have got the [jxl binary](/docs/labs/jxl/) before proceeding.
 

--- a/content/en/docs/labs/jenkins/importing.md
+++ b/content/en/docs/labs/jenkins/importing.md
@@ -4,6 +4,17 @@ linktitle: Importing Projects
 description: Importing Jenkinsfile based projects
 weight: 50
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 Once you have [added one or more Jenkins Servers to the registry](/docs/labs/jenkins/getting-started/#adding-jenkins-servers) you can import a `Jenksinfile` based project.
 

--- a/content/en/docs/labs/jenkins/overview.md
+++ b/content/en/docs/labs/jenkins/overview.md
@@ -4,6 +4,17 @@ linktitle: Overview
 description: Overview of the Jenkins and Jenkins X interoperability
 weight: 10
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 The [Trigger Jenkins Proposal](https://github.com/jstrachan/enhancements/blob/jenkins-trigger/proposals/trigger-jenkins/README.md) aims to improve the interoperability of Jenkins and Jenkins X so you can use both together to solve all of your CI//CD needs.
 

--- a/content/en/docs/labs/jxl.md
+++ b/content/en/docs/labs/jxl.md
@@ -5,6 +5,17 @@ type: docs
 description: Getting the jxl binary so you can try the Labs features
 weight: 1
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 Before you start using the Labs features you need to get the Labs Command Line tool called `jxl`.
 

--- a/content/en/docs/labs/wizard/_index.md
+++ b/content/en/docs/labs/wizard/_index.md
@@ -5,7 +5,17 @@ type: docs
 description: Improved import and quickstart wizards for Jenkins and Jenkins X
 weight: 50
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 The [jxl binary](/docs/labs/jxl/) includes improved wizards for importing projects and creating projects from quickstarts
 

--- a/content/en/docs/labs/wizard/jenkins.md
+++ b/content/en/docs/labs/wizard/jenkins.md
@@ -4,6 +4,17 @@ linktitle: Jenkins Support
 description: Support for remote Jenkins servers
 weight: 30
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
+
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 When importing a project `jxl project import` looks for a `Jenkinfile` in the source code. 
 

--- a/content/en/docs/labs/wizard/overview.md
+++ b/content/en/docs/labs/wizard/overview.md
@@ -4,7 +4,17 @@ linktitle: Overview
 description: Overview of the wizard improvements
 weight: 10
 ---
+{{% alert %}}
+**NOTE: This current experiment is now closed. The work done and feedback we have received will be used to enhance Jenkins X in future versions**
 
+**This code should not be used in production, or be adopted for usage.  It should only be used to provide feedback to the Labs team.**
+
+Thank you for your participation,
+
+-Labs
+
+
+{{% /alert %}}
 
 The [jxl binary](/docs/labs/jxl/) includes an improved wizard for importing projects or creating new projects from quickstarts.
 


### PR DESCRIPTION
This PR adds the warning from the initial labs page to all the labs pages. That way, people will know that it is experimental and that the current labs are closed no matter whether they navigate through the left-hand navigation, or stumble upon one of the pages through, let's say, Google search.