### PR TITLE
fix: setting baseURL to fix broken sitemap

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://jenkins-x.io"
 title = "Jenkins X - Cloud Native CI/CD Built On Kubernetes"
 
 enableRobotsTXT = true


### PR DESCRIPTION
Because the config.toml doesn't have a proper base URL set, the sitemap is not generating full URLs and thus is invalid in Google. This change will let the sitemap generate full URLs and allow Google to crawl the sitemap.