### PR TITLE
fix: making sure base URL for the release site is set to https://jenkins-x.io

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -65,6 +65,7 @@ pipelineConfig:
               - -d
               - jenkins-x-website
               - --enableGitInfo
+              - --baseURL https://jenkins-x.io
 
           ## add, commit, and push changes
           - image: gcr.io/jenkinsxio/builder-go


### PR DESCRIPTION
Will ensure the sitemap entries contain full URLs

fixes #2763