### PR TITLE
fix: Parsing yaml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,6 @@ services:
       - .:/workdir
   linkchecker:
     image: chabad360/htmlproofer:latest
-    command: "htmlproofer ./public --allow-hash-href --disable-external --check-html --checks-to-ignore ScriptCheck --empty-alt-ignore --file-ignore /.*apidocs.*/,/.*\/zh.*/,/.*\/es.*/,/.*\/docs\/reference\/api.*/,/.*\/docs\/reference\/config.*/,/.*\/community\/events.*/"
+    command: 'htmlproofer ./public --allow-hash-href --disable-external --check-html --checks-to-ignore ScriptCheck --empty-alt-ignore --file-ignore /.*apidocs.*/,/.*\/zh.*/,/.*\/es.*/,/.*\/docs\/reference\/api.*/,/.*\/docs\/reference\/config.*/,/.*\/community\/events.*/'
     volumes:
       - ./public:/public


### PR DESCRIPTION
Fixes #2790 

## Cause of the Problem:
Problem arises from using double quotes in [docker-compose.yml](https://github.com/jenkins-x/jx-docs/blob/master/docker-compose.yml) file.
The line causing the issue is: 
```    
command: "htmlproofer ./public --allow-hash-href --disable-external --check-html --checks-to-ignore ScriptCheck --empty-alt-ignore --file-ignore /.*apidocs.*/,/.*\/zh.*/,/.*\/es.*/,/.*\/docs\/reference\/api.*/,/.*\/docs\/reference\/config.*/,/.*\/community\/events.*/"
```
To check the configuration of the YAML file visit http://www.yamllint.com/ 

## Fix: 
Using single quotes instead of double quotes.