### PR TITLE
fix: Typo in community documentation

### DIFF
--- a/content/en/community/documentation/_index.md
+++ b/content/en/community/documentation/_index.md
@@ -162,7 +162,7 @@ It may be a good idea to run the server in a separate terminal so that you can k
 
 ## Contribution workflow
 
-Now that you have your local preview environment, the [contribution workflow](/community/documentation/workflow/) documnentation guides you through the steps to create your first pull request.
+Now that you have your local preview environment, the [contribution workflow](/community/documentation/workflow/) documentation guides you through the steps to create your first pull request.
 
 ## Reference
 


### PR DESCRIPTION
Found and fixed a spelling error in the community documentation.

![Screenshot from 2020-05-17 00-43-11](https://user-images.githubusercontent.com/33171576/82130061-95844500-97e5-11ea-9b79-4dcd3be46471.png)
