### PR TITLE
fix: restoring /docs redirect

### DIFF
--- a/content/en/docs/getting-started/_index.html
+++ b/content/en/docs/getting-started/_index.html
@@ -5,7 +5,8 @@ description="How to get up and running with Jenkins X"
 
 aliases = [
     "/getting-started/",
-    "/docs/getting-started"
+    "/docs/getting-started",
+    "/docs"
 ]
 
 type= "docs"


### PR DESCRIPTION
The /docs direct went missing, causing a 404 on a common page URL. Restoring the alias here.