### PR TITLE
docs: removed Google Analytics and replaced it with Google Tag Manager

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,8 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5BWMXGJ"
+	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
 <nav class="js-navbar-scroll navbar navbar-expand-lg navbar-light bg-light {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
 	<a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -23,13 +23,15 @@
 </script>
 <script>hljs.initHighlightingOnLoad();</script>
 <!-- CDF -->
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-154682132-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-154682132-3');
-</script>
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-5BWMXGJ');</script>
+  <!-- End Google Tag Manager -->
+
+
 <script type="text/javascript" src="//downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">window.dojoRequire(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us7.list-manage.com","uuid":"d0c128ac1f69ba2bb20742976","lid":"84d053b0a0","uniqueMethods":true}) })</script>
 {{ partial "hooks/body-end.html" . }}


### PR DESCRIPTION
- Removed Google Analytics
- Added Google Tag Manager

Both were in the <head>. Google Tag Manager is a faster, more flexible method of pushing tags like Google Analytics on the web.