### PR TITLE
docs: unpublishing old blog post

### DIFF
--- a/content/en/blog/news/provision-jx-clusters-terraform.md
+++ b/content/en/blog/news/provision-jx-clusters-terraform.md
@@ -7,7 +7,7 @@ categories: [blog]
 keywords: [terraform,IaC,provisioning,k8s]
 slug: "terraform-jenkins-x"
 aliases: []
-published: false
+draft: true
 author: Oscar Medina
 ---
 

--- a/content/en/blog/news/provision-jx-clusters-terraform.md
+++ b/content/en/blog/news/provision-jx-clusters-terraform.md
@@ -7,6 +7,7 @@ categories: [blog]
 keywords: [terraform,IaC,provisioning,k8s]
 slug: "terraform-jenkins-x"
 aliases: []
+published: false
 author: Oscar Medina
 ---
 


### PR DESCRIPTION
The instructions on this post are not relevant given that we now have the Terraform modules published.