### PR TITLE
fix: Added correct link for Vault for EKS

### DIFF
--- a/content/en/docs/install-setup/installing/create-cluster/eks.md
+++ b/content/en/docs/install-setup/installing/create-cluster/eks.md
@@ -60,7 +60,7 @@ module "eks-jx" {
 ```
 
 The IAM user does not need any permissions attached to it.
-For more information, refer to [Configuring Vault for EKS](https://jenkins-x.io/docs/getting-started/setup/boot/clouds/amazon/#configuring-vault-for-eks) in the Jenkins X documentation.
+For more information, refer to [Configuring Vault for EKS](/docs/install-setup/installing/boot/clouds/amazon/#configuring-vault-for-eks) in the Jenkins X documentation.
 
 Once you have your initial configuration, you can apply it by running:
 


### PR DESCRIPTION
Configuring Vault for EKS link redirected to 404. I have added the correct link pointing to https://jenkins-x.io/docs/install-setup/installing/boot/clouds/amazon/#configuring-vault-for-eks