### PR TITLE
fix: tell minikube to use VM

### DIFF
--- a/content/en/docs/v3/guides/infra/minikube.md
+++ b/content/en/docs/v3/guides/infra/minikube.md
@@ -17,7 +17,7 @@ This guide will walk you though how to setup Jenkins X on your laptop using [min
 * You need to create a `minikube` cluster via the following command:
 
 ```bash
-minikube start --cpus 4 --memory 8048 --disk-size=100g --addons=ingress
+minikube start --cpus 4 --memory 8048 --disk-size=100g --addons=ingress --vm=true
 ```
  
 ## Setup


### PR DESCRIPTION
When trying to use Docker with minikube, I got this notification after minikube create the cluster:

```
Due to networking limitations of driver docker on darwin, ingress addon is not supported.
Alternatively to use this addon you can use a vm-based driver:

	'minikube start --vm=true'

To track the update on this work in progress feature please check:
https://github.com/kubernetes/minikube/issues/7332
```