### PR TITLE
fix: build pack pipeline file name

### DIFF
--- a/content/en/docs/build-test-preview/jenkins-x-pipelines/_index.md
+++ b/content/en/docs/build-test-preview/jenkins-x-pipelines/_index.md
@@ -26,7 +26,7 @@ Jenkins X pipelines are configured in YAML configuration files. The files can be
 found in two locations serving distinct purposes:
 
 * In the Jenkins X project repository, called `jenkins-x.yml`.
-* In the build packs for creating applications, if it is specified in the project repository `jenkins-x.yml` file under `buildPack`.
+* In the build packs for creating applications, if it is specified in the project repository `pipeline.yaml` file under `buildPack`.
 
 ## Pipeline types
 


### PR DESCRIPTION
Documentation incorrectly said the pipeline file in a build pack is named `jenkins-x.yml` but it's `pipeline.yaml`.

