### PR TITLE
docs: how to change strategy for jx gitops upgarde

### DIFF
--- a/content/en/docs/v3/guides/upgrade.md
+++ b/content/en/docs/v3/guides/upgrade.md
@@ -41,6 +41,14 @@ git push
 
 It is possible that you will have merge conflicts.  You can follow the inline git helper messages to resolve conflicts - or use your IDE to help figure out the merge issues. Usually if there are conflicts its safest to use the upstream version; particularly from the `versionStream` dir.
 
+Under the hood Kpt is used to fetch changes from the upstream defined in each Kptfile.  
+By default the `versionStream` directory has a Kpt strategy of `force-delete-replace` which removes all your changes in that folder. In order to merge your changes with the ones coming from upstream, add a file: `.jx/gitops/kpt-strategy.yaml` with the following content:
+```yaml
+config:
+  - relativePath: versionStream
+    strategy: resource-merge
+```
+
 Once ready, make a pull request onto your cluster repository, review changes and merge.  The [Jenkins X git operator](https://github.com/jenkins-x/jx-git-operator) will automatically apply the upgrades into your cluster.
 
 


### PR DESCRIPTION
Or maybe, we just replace this strategy here: https://github.com/jenkins-x/jx-gitops/blob/5194dc6e8628be69d56abf09cff86f47adacb979/pkg/cmd/kpt/update/update.go#L251
with `resource-merge`, unless @rawlingsj has a really good reason for doing this :p
