### PR TITLE
docs: Improved multi-cluster guide

### DIFF
--- a/content/en/docs/v3/guides/multi-cluster.md
+++ b/content/en/docs/v3/guides/multi-cluster.md
@@ -11,14 +11,31 @@ We recommend using separate clusters for your `Preprod` and `Production` environ
 
 ## Setting up multi cluster
 
-Follow new [getting started approach](/docs/v3/getting-started/) to setup a new cluster. For `Preprod` and `Production` you typically won't need lots of the development tools like lighthouse and tekton; you will just want your actual applications and any additional services you need to run them (e.g. maybe nginx-ingress or cert-manager etc).
+1. Follow new [getting started approach](/docs/v3/getting-started/) to setup a new Development Cluster (or skip this step if already in place). 
 
-Then when you have a git repository URL for your `Preprod` or `Production`  cluster, [import the git repository](/docs/v3/develop/create-project/#import-an-existing-project) like you would any other git repository into your development cluster using the [jx project import](https://github.com/jenkins-x/jx-project/blob/master/docs/cmd/project_import.md) command:
+2. Follow the mentioned approach at the previous point in order to setup new and additional clusters for the desired remote environments:
+    * For remote environments (e.g. `Preprod` and `Production`) you typically won't need lots of the development tools such as:
+      * Lighthouse
+      * Tekton
+      * Webhooks
+    * And install only services to run and expose your applications, e.g.:
+      * Nginx-ingress
+      * Cert-manager
+3. Then when you have a git repository URL for your `Preprod` or `Production` cluster, [import the git repository](/docs/v3/develop/create-project/#import-an-existing-project) like you would any other git repository into your Development cluster using the [jx project import](https://github.com/jenkins-x/jx-project/blob/master/docs/cmd/project_import.md) command (command should be run in the `jx` namespace):
+    
+    ```bash 
+    jx project import --url https://github.com/myowner/my-prod-repo.git
+    ```
+    
+    This will create a Pull Request on your development cluster git repository to link to the `Preprod` or `Production` git repository on promotions of apps. `N.B`: Jenkins-X will push additional configuration files to the created Pull Request, so it is recommended to wait until the Pull Request is auto-merged and avoid manual intervention.
 
-```bash 
-jx project import --url https://github.com/myowner/my-prod-repo.git
-```        
 
-This will create a Pull Request on your development cluster git repository to link to the `Preprod` or `Production` git repository on promotions of apps.
+
+Once everything is correctly setup, it will be possible to deploy applications to the newly created remote environment/s. 
+
+
+     
+
+
 
 


### PR DESCRIPTION
This commit is improving the multi-cluster guide for the users. Probably it would be great to create an example repo among the jx3 proposed ones (e.g. `jx3-kubernetes-prod`, where unnecessary resources are already excluded) and refer to it in the multi-cluster guide.


