### PR TITLE
fix(menu): expand sidebar menu by default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -132,7 +132,7 @@ prism_syntax_highlighting = true
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = true
+sidebar_menu_compact = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)


### PR DESCRIPTION
# Description

Expand sidebar menu by default in order to see directly where to look for a particular section instead of having to click on each of them


# Checklist:

- [X] I have mentioned the appropriate type(scope), as referenced [here](
) in the commit message and PR title for the semantic checks to pass.
- [X] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [X] Any dependent changes have already been merged.

