### PR TITLE
fix: Expand only "About" menu section when opening v3 doc

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -190,7 +190,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/jenkins-x/jx-docs/i
 # Versioning
 [[params.versions]]
 version = "v3.x"
-url = "/v3"
+url = "/v3/about"
 dirpath = "v3"
 
 [[params.versions]]


### PR DESCRIPTION
# Description

Expand only "About" menu section when opening v3 doc

# Checklist:

- [X] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [X] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [X] Any dependent changes have already been merged.

