### PR TITLE
docs: invalid path to .../git-operator/job.yaml

### DIFF
--- a/content/en/v3/about/how-it-works.md
+++ b/content/en/v3/about/how-it-works.md
@@ -26,7 +26,7 @@ That command essentially installs the [git operator](https://github.com/jenkins-
 
 ### Git Operator
 
-The [git operator](https://github.com/jenkins-x/jx-git-operator) works by polling the git repository looking for changes and running a kubernetes Job on each change. The Job resource is defined inside the git repository at **.jx/git-operator/job.yaml**
+The [git operator](https://github.com/jenkins-x/jx-git-operator) works by polling the git repository looking for changes and running a kubernetes Job on each change. The Job resource is defined inside the git repository at **versionStream/git-operator/job.yaml**
 
 You can view the boot Job log via the command:
 
@@ -43,7 +43,7 @@ Or you can browse the log in the Octant UI in the operations tab.
 
 The boot job runs on startup and on any git commit to the GitOps repository you used to install the operator.
 
-The boot job is defined in **.jx/git-operator/job.yaml** in git and essentially:
+The boot job is defined in **versionStream/git-operator/job.yaml** in git and essentially:
 
 
 * Runs the generate step


### PR DESCRIPTION

# Description

I'm pretty sure that the file has moved from `.jx/` to `versionStream/` in v3.

Fixes # (issue)

incorrect docs

# Checklist:

- [X] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [NA] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [NA] Any dependent changes have already been merged.

