### PR TITLE
fix(migration): add missing 'jx gitops repository export' doc link

### DIFF
--- a/content/en/v3/admin/guides/migrate/v2.md
+++ b/content/en/v3/admin/guides/migrate/v2.md
@@ -38,7 +38,7 @@ ls -al helmfile.yaml
 kubectl get sourcerepository
 ```
 
-* now run the [jx gitops repository export]() command
+* now run the [jx gitops repository export](https://github.com/jenkins-x/jx-gitops/blob/master/docs/cmd/jx-gitops_repository_export.md) command
 
 * the local file `.jx/gitops/source-config.yaml` should have been modified with the exported repositories
 * review the changes to this file - remove any projects you don't want to import


### PR DESCRIPTION
# Description

Add missing 'jx gitops repository export' doc link

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

