### PR TITLE
chore: update link for kubernetes-external-secrets

### DIFF
--- a/content/en/v3/about/overview/_index.md
+++ b/content/en/v3/about/overview/_index.md
@@ -61,7 +61,7 @@ Contains the [nginx-ingress](https://github.com/helm/charts/tree/master/stable/n
 
 ### `secret-infra` 
 
-* **kubernetes-external-secrets** contains the [godaddy/kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) service for handling `ExternalSecrets`. See [how we use secrets](/v3/guides/secrets/))
+* **kubernetes-external-secrets** contains the [external-secrets/kubernetes-external-secrets](https://github.com/external-secrets/kubernetes-external-secrets) service for handling `ExternalSecrets`. See [how we use secrets](/v3/guides/secrets/))
 * **pusher-wave** contains the [pusher/wave](https://github.com/pusher/wave) service for performing a rolling upgrade of any microservice which consumes `Secret` resources from either vault or a cloud providers secret store and the secrets change in the underlying store 
 
 the following are optional extras if not using your cloud providers native secret manager:


### PR DESCRIPTION
# Description
Update link for `kubernetes-external-secrets`
- Before: https://github.com/godaddy/kubernetes-external-secrets
- After: https://github.com/external-secrets/kubernetes-external-secrets

Someone will also need to update the [diagram on whimsical](https://whimsical.com/embed/SnJBgXG6jz9pqQewiDTNRt@2Ux7TurymNDXVRa4FpLk).

![image](https://user-images.githubusercontent.com/10026538/103492660-421e4000-4e24-11eb-85d4-f74ca94d8727.png)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

