### PR TITLE
chore: add a note on ecr repo creation before running quickstart or imports

### DIFF
--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -7,14 +7,12 @@ spec:
     always_run: true
     optional: false
     trigger: "/test"
-    rerun_command: "/retest"
     source: "pullrequest.yaml"
   - name: preview
     context: "preview"
     always_run: true
     optional: false
     trigger: "/jx preview"
-    rerun_command: "/retest"
     source: "preview.yaml"
   postsubmits:
   - name: release

--- a/content/en/v3/admin/platforms/eks.md
+++ b/content/en/v3/admin/platforms/eks.md
@@ -14,7 +14,8 @@ aliases:
 ---
 **NOTE**
 
-Ensure you are logged into GitHub else you will get a 404 error when clicking the links below
+* Ensure you are logged into GitHub else you will get a 404 error when clicking the links below
+* ECR repository needs to be created before running the quickstart or importing existing projects.
 
 ---
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

# Description
ECR repository needs to be created before running a quickstart, else kaniko will complain when it tries to push the image.

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

