### PR TITLE
chore: add GitHub action to build image for jx-docs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,17 @@
+name: Build Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build Image
+        run: |
+          docker login ghcr.io --username ${{ secrets.GHCR_USER }} --password ${{secrets.GHCR_TOKEN}}
+          docker build . -t ghcr.io/jenkins-x/jx-docs/jx-docs:latest -f Dockerfile.all
+          docker push ghcr.io/jenkins-x/jx-docs/jx-docs:latest

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -1,0 +1,13 @@
+FROM gcr.io/jenkinsxio/hugo-extended:0.74.0-10 as builder
+
+WORKDIR /work
+COPY . .
+RUN git submodule update --init --recursive && \
+	./scripts/ci/update-content.sh && \
+	npm install && \
+	hugo -d public
+
+FROM abiosoft/caddy
+EXPOSE 2015
+WORKDIR /srv
+COPY --from=builder /work/public .


### PR DESCRIPTION
# Description

Visit this website is very slow from my country. It'd good to have a docker image. So I can deploy it. I'm considering deploy it to `https://jx.jenkins-zh.cn`.

In order to make sure it works. There're two GitHub secrets needed. They are the username and password (or token) of a GitHub account which can push the images to `ghcr.io`.

* `GHCR_USER`
* `GHCR_TOKEN`

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

