### PR TITLE
fix: use compact menu by default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -132,7 +132,7 @@ prism_syntax_highlighting = true
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)


### PR DESCRIPTION
we have lots of documentation sections so auto-expanding all the docs is confusing