### PR TITLE
Change capitalization of Testcontainers in docs

### DIFF
--- a/content/en/v3/develop/faq/_index.md
+++ b/content/en/v3/develop/faq/_index.md
@@ -116,7 +116,7 @@ To add a new chart add to the `helmfiles/mynamespace/helmfile.yaml` file follow 
 
 To add a new kubernetes resource [follow the add resources guide](/v3/develop/apps/#adding-resources).
       
-## How do I use testcontainers?
+## How do I use Testcontainers?
 
 If you want to use a container, such as a database, inside your pipeline so that you can run tests against your database inside your pipeline then use a [sidecar container in Tekton](https://tekton.dev/vault/pipelines-v0.16.3/tasks/#specifying-sidecars).
 


### PR DESCRIPTION
# Description

In case I interpret the docs correctly to reference the [https://www.testcontainers.org/](Testcontainers) project, I change the capitalization to the official form.

In case this was not supposed to talk about the Testcontainers project, maybe it is better to rephrase as:
`How do I use containers for testing?`