### PR TITLE
fix: Install operator: remove delete_repo permission

### DIFF
--- a/content/en/v3/admin/setup/operator/_index.md
+++ b/content/en/v3/admin/setup/operator/_index.md
@@ -37,7 +37,7 @@ Note also that the same pipeline user and token is reused by default for all pip
 
 To create a git token for passing into the operator use this button:
 
-<a href="https://github.com/settings/tokens/new?scopes=repo,read:user,read:org,user:email,admin:repo_hook,delete_repo,write:packages,read:packages,write:discussion,workflow" target="github" class="btn bg-primary text-light">Create new GitHub Token</a> 
+<a href="https://github.com/settings/tokens/new?scopes=repo,read:user,read:org,user:email,admin:repo_hook,write:packages,read:packages,write:discussion,workflow" target="github" class="btn bg-primary text-light">Create new GitHub Token</a> 
 
 ## Installing the operator
 

--- a/content/en/v3/admin/setup/operator/_index.md
+++ b/content/en/v3/admin/setup/operator/_index.md
@@ -32,7 +32,6 @@ You can always setup webhooks by hand yourself whenever a git repository is [cre
 
 Note also that the same pipeline user and token is reused by default for all pipelines on [all repositories created or imported](/v3/develop/create-project/) which will need read, write and webhook permissions on all of those repositories too. Though if you really want you can change this later on by [editing the pipeline token](/v3/guides/secrets/#edit-secrets).
 
-
 ## Create a git token
 
 To create a git token for passing into the operator use this button:


### PR DESCRIPTION
fix: Remove delete_repo as pre-populated GitHub PAT token permissions as it seems not to be in use.
Signed-off-by: Elias Abacioglu elias.rabi@gmail.com

# Description

It's not smart to ask for more permissions than what is needed from a security perspective.
Remove delete_repo as pre-populated GitHub PAT token permissions as it seems not to be in use.


# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

