### PR TITLE
fix: correct link for storage

### DIFF
--- a/content/en/v3/admin/setup/config/repository.md
+++ b/content/en/v3/admin/setup/config/repository.md
@@ -41,7 +41,7 @@ repository: bucketrepo
 
 By default the local file system in the bucket repo is used to store artifacts.
 
-To enable cloud storage for artifacts in `bucketrepo` you need to enable the `storage.repository` configuration in which case a cloud bucket is used instead. See the [storage section for more details](#storage).
+To enable cloud storage for artifacts in `bucketrepo` you need to enable the `storage.repository` configuration in which case a cloud bucket is used instead. See the [storage section for more details](/v3/admin/setup/storage.md).
 
 ### None
 


### PR DESCRIPTION
# Description

Fixes the link to the storage section.

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

