### PR TITLE
chore: fix old jx-cli links

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -167,7 +167,7 @@ linkTitle = "Jenkins X - Cloud Native CI/CD Built On Kubernetes"
 
         <a href="/docs/" class="btn btn-secondary btn-lg"> <i class="fa fa-paperclip fa-2x align-middle"></i> Use 2.x </a>&nbsp;
 
-        <a href="https://github.com/jenkins-x/jx-cli" class="btn btn-secondary btn-lg" target="_BLANK" rel="noopener noreferrer"><i class="fa fa-github fa-2x align-middle"></i>  View Repo </a>
+        <a href="https://github.com/jenkins-x/jx" class="btn btn-secondary btn-lg" target="_BLANK" rel="noopener noreferrer"><i class="fa fa-github fa-2x align-middle"></i>  View Repo </a>
       </p>
     </div>
   </section>

--- a/content/en/docs/reference/components/source.md
+++ b/content/en/docs/reference/components/source.md
@@ -45,7 +45,7 @@ Here we'll call out of some of the main repositories in the above organisations:
 
 The following repositories are for [version 3.x](https://jenkins-x.io/v3/):
 
-* [jenkins-x/jx-cli](https://github.com/jenkins-x/jx-cli) is the 3.x CLI 
+* [jenkins-x/jx](https://github.com/jenkins-x/jx) is the 3.x CLI 
 * [jenkins-x/jx3-pipeline-catalog](https://github.com/jenkins-x/jx3-pipeline-catalog) the main [Pipeline Catalog](https://jenkins-x.io/v3/guides/pipeline-catalog/)
 * [jenkins-x/jxr-versions](https://github.com/jenkins-x/jxr-versions) contains the [version stream](/about/concepts/version-stream/) - the stable versions of all _charts_ and CLI _packages_
 

--- a/content/en/v3/about/changes.md
+++ b/content/en/v3/about/changes.md
@@ -56,4 +56,4 @@ jx dash
   * This is all handled by the new [jx-preview](https://github.com/jenkins-x/jx-preview) plugin
   * This also opens up the possibility of using multiple namespaces per preview; or using canary releases on multiple previews into a shared environment.
   
-* The new Jenkins X version 3 CLI [jx-cli](https://github.com/jenkins-x/jx) is now plugins all the way down; so that all of the features are implemented by [separate binary plugins](https://github.com/jenkins-x/jx#plugins) making the CLI more modular and easier to work on.
+* The new Jenkins X version 3 CLI [jx](https://github.com/jenkins-x/jx) is now plugins all the way down; so that all of the features are implemented by [separate binary plugins](https://github.com/jenkins-x/jx#plugins) making the CLI more modular and easier to work on.

--- a/content/en/v3/about/extending.md
+++ b/content/en/v3/about/extending.md
@@ -28,7 +28,7 @@ It turns out anyone can create a new plugin to wrap up some functionality that i
 
 Plugins usually written in [Go](https://golang.org/) as it has awesome Kubernetes support and generates easy to use statically compiled binaries - though you are free to create plugins in any programming language.
 
-If you wish to create a new plugin try browse the [jenkins-x-plugins organisation](https://github.com/jenkins-x-plugins) for inspiration or check out the [standard plugins used in the jx-cli](https://github.com/jenkins-x/jx#plugins)
+If you wish to create a new plugin try browse the [jenkins-x-plugins organisation](https://github.com/jenkins-x-plugins) for inspiration or check out the [standard plugins used in the jx cli](https://github.com/jenkins-x/jx#plugins)
   
 
 ### Developing Plugins

--- a/content/en/v3/admin/setup/upgrades/cli.md
+++ b/content/en/v3/admin/setup/upgrades/cli.md
@@ -20,13 +20,13 @@ To upgrade jx subcommand plugins run:
 jx upgrade plugins
 ```
 
-The jx-cli version used to upgrade to is derived from the Jenkins X [version stream](/about/concepts/version-stream/).  
+The `jx` CLI version used to upgrade to is derived from the Jenkins X [version stream](/about/concepts/version-stream/).  
 
-If you have not installed Jenkins X or are not connected to a Kubernetes cluster with Jenkins X running then the jx-cli version defaults to the latest version stream git repository [here](https://github.com/jenkins-x/jxr-versions/blob/master/packages/jx.yml)
+If you have not installed Jenkins X or are not connected to a Kubernetes cluster with Jenkins X running then the `jx` CLI version defaults to the latest version stream git repository [here](https://github.com/jenkins-x/jxr-versions/blob/master/packages/jx.yml)
 
-If you are running the `jx upgrade cli` command from within a cloned cluster git repository (one that has the helmfile.yaml and jx-requirements.yml files at the root folder) then the [version stream](/about/concepts/version-stream/) URL used to find the correct jx-cli version use comes from the local file `versionStream/Kptfile`.  The reason for this is when switching [version stream](/about/concepts/version-stream/) (like moving to LTS) you need to match the jx-cli version stored in that desired vesrion stream, as they may be different to you previous [version stream](/about/concepts/version-stream/).
+If you are running the `jx upgrade cli` command from within a cloned cluster git repository (one that has the helmfile.yaml and jx-requirements.yml files at the root folder) then the [version stream](/about/concepts/version-stream/) URL used to find the correct jx CLI version use comes from the local file `versionStream/Kptfile`.  The reason for this is when switching [version stream](/about/concepts/version-stream/) (like moving to LTS) you need to match the jx CLI version stored in that desired vesrion stream, as they may be different to you previous [version stream](/about/concepts/version-stream/).
 
-If you want to find the jx-cli version that matches the [version stream](/about/concepts/version-stream/) used by your cluster git repository then pass this addional flag:
+If you want to find the `jx` CLI version that matches the [version stream](/about/concepts/version-stream/) used by your cluster git repository then pass this addional flag:
 
 ```bash
 jx upgrade cli --from-environment

--- a/content/en/v3/devops/patterns/push_version_changes.md
+++ b/content/en/v3/devops/patterns/push_version_changes.md
@@ -13,6 +13,6 @@ Using the **push** model means that as you create a new versioned release of an 
 We do this in Jenkins X using the [updatebot plugin](https://github.com/jenkins-x-plugins/jx-updatebot) as part of a release pipeline. The [go-plugin release pipelines](https://github.com/jenkins-x/jx3-pipeline-catalog/blob/master/packs/go-plugin/.lighthouse/jenkins-x/release.yaml#L38) pipelines have a `promote-release` which uses the updatebot plugin to promote the new version to other git repositories. Here are some examples:
 
 * the [jenkins-x/lighthouse](https://github.com/jenkins-x/lighthouse)  repository has this [.jx/updatebot.yaml](https://github.com/jenkins-x/lighthouse/blob/master/.jx/updatebot.yaml) to update the version stream on a release
-* the [jx-gitops](https://github.com/jenkins-x/jx-gitops) repository has this  [.jx/updatebot.yaml](https://github.com/jenkins-x/jx-gitops/blob/master/.jx/updatebot.yaml) to update the plugin in the jx-cli repository
+* the [jx-gitops](https://github.com/jenkins-x/jx-gitops) repository has this  [.jx/updatebot.yaml](https://github.com/jenkins-x/jx-gitops/blob/master/.jx/updatebot.yaml) to update the plugin in the jx cli repository
 
 Creating Pull Requests to modify versions means the team looking after the repository can decide when and how to merge the Pull Request; e.g. periodically or in quiet times when there are no serious production issues to resolve.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

