### PR TITLE
fix: add missing repository url for the "jx gitops helmfile add" command

### DIFF
--- a/content/en/v3/admin/setup/ingress/oauth/_index.md
+++ b/content/en/v3/admin/setup/ingress/oauth/_index.md
@@ -40,7 +40,7 @@ We will be editing helmfiles so clone your cluster git repository and move into 
  
 Add the oauth2 proxy helm chart, this will redirect requests to to the configured OAuth provider:
 ```bash
-jx gitops helmfile add --chart k8s-at-home/oauth2-proxy
+jx gitops helmfile add --chart k8s-at-home/oauth2-proxy --repository https://k8s-at-home.com/charts/
 jx gitops helmfile resolve
 ```
 you should see the new chart added to the end of the file `./helmfiles/jx/helmfile.yaml`


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

