### PR TITLE
docs: fix git command because default GitHub branch name is 'main'.

### DIFF
--- a/content/en/v3/admin/platforms/minikube/_index.md
+++ b/content/en/v3/admin/platforms/minikube/_index.md
@@ -73,7 +73,7 @@ ingress:
 ```bash
 git add *
 git commit -a -m "fix: configurations for local minikube"
-git push origin master
+git push origin main
 ```
 
 * <a href="/v3/guides/operator/" class="btn bg-primary text-light">Install the Git Operator</a> 

--- a/content/en/v3/admin/platforms/on-premise/_index.md
+++ b/content/en/v3/admin/platforms/on-premise/_index.md
@@ -91,7 +91,7 @@ ingress:
 ```bash
 git add *
 git commit -a -m "fix: added domain"
-git push origin master
+git push origin main
 ```
 
 * ensure you are connected to your cluster so you can run the following [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) commands 

--- a/content/en/v3/admin/platforms/openshift/_index.md
+++ b/content/en/v3/admin/platforms/openshift/_index.md
@@ -64,7 +64,7 @@ ingress:
 ```bash
 git add *
 git commit -a -m "fix: added domain"
-git push origin master
+git push origin main
 ```
 
 * <a href="/v3/guides/operator/" class="btn bg-primary text-light">Install the Git Operator</a> 


### PR DESCRIPTION
# Description

The default branch name for the following template repository is `main`, 

-  [jx3-gitops-repositories/jx3-minikube](https://github.com/jx3-gitops-repositories/jx3-minikube/generate)
- [jx3-gitops-repositories/jx3-kubernetes](https://github.com/jx3-gitops-repositories/jx3-kubernetes/generate)
- [jx3-gitops-repositories/jx3-openshift](https://github.com/jx3-gitops-repositories/jx3-openshift/generate)

However, the commands listed in Getting Started assume a `master` branch.

```
git push origin master
```

Therefore, we have modified the command to assume the `main` branch.

```
git push origin main
```

Fixes #3309 

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

