### PR TITLE
docs: Expand and fix documentation for jx gitops git subcommands

### DIFF
--- a/content/en/v3/develop/reference/jx/gitops/git/clone/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/clone/_index.md
@@ -15,7 +15,11 @@ jx gitops git clone
 
 ### Synopsis
 
-Clones the cluster git repository using the URL, git user and token from the Secret
+Clones the cluster git repository from the URL provided to the `jx-git-operator` watching the said repository, and authenticating as git user with token provided by `jx-boot` secret, also provided by `jx-git-operator` installation.
+
+### Details
+
+Effectively this command runs `jx gitops git setup` before proceeding to simply clone the repository into either the folder passed in via `--clone-dir` or into the `./setup` directory.
 
 ### Examples
 
@@ -26,11 +30,11 @@ Clones the cluster git repository using the URL, git user and token from the Sec
 ### Options
 
 ```
-      --clone-dir string            the directory to clone the repository to
-      --credentials-file string     The destination of the git credentials file to generate. If not specified uses $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials
+      --clone-dir string            the directory to clone the repository to. Default value is `./source` relative to the directory in which the command is running
+      --credentials-file string     The destination of the git credentials file to generate. If not specified uses $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials. 
   -d, --dir string                  the directory to run the git setup command from
-  -e, --email string                the git user email to use if one is not setup
-      --fake-in-cluster             for testing: lets you fake running this command inside a kubernetes cluster so that it can create the file: $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials
+  -e, --email string                the git user email to use if one is not setup. Default value is `jenkins-x@googlegroups.com` if no other is specified
+      --fake-in-cluster             for testing: lets you fake running this command inside a Kubernetes cluster so that it can create the file: $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials
       --git-provider string         the git provider URL. If not specified its detected from the git operator Secret or defaults to https://github.com
   -h, --help                        help for clone
   -n, --name string                 the git user name to use if one is not setup
@@ -39,8 +43,6 @@ Clones the cluster git repository using the URL, git user and token from the Sec
       --password string             the git password/token to use. if not specified it is detected from the git operator Secret
       --secret string               the name of the Secret to find the git URL, username and password for creating a git credential if running inside the cluster (default "jx-boot")
 ```
-
-
 
 ### Source
 

--- a/content/en/v3/develop/reference/jx/gitops/git/clone/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/clone/_index.md
@@ -15,11 +15,13 @@ jx gitops git clone
 
 ### Synopsis
 
-Clones the cluster git repository from the URL provided to the `jx-git-operator` watching the said repository, and authenticating as git user with token provided by `jx-boot` secret, also provided by `jx-git-operator` installation.
+Clones the cluster git repository from the URL provided to the `jx-git-operator` watching the said repository, and
+authenticating as git user with token provided by `jx-boot` secret, also provided by `jx-git-operator` installation.
 
 ### Details
 
-Effectively this command runs `jx gitops git setup` before proceeding to simply clone the repository into either the folder passed in via `--clone-dir` or into the `./setup` directory.
+Effectively this command runs `jx gitops git setup` before proceeding to simply clone the repository into either the
+folder passed in via `--clone-dir` or into the `./setup` directory.
 
 ### Examples
 

--- a/content/en/v3/develop/reference/jx/gitops/git/get/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/get/_index.md
@@ -15,7 +15,21 @@ jx gitops git get
 
 ### Synopsis
 
-Gets a file from a git repository or environment git repository
+Gets a file from a git repository or Jx Environment git repository
+
+### Details
+
+Copies a file specified by `--file` flag from a Git repository into local file system. The repository from which the file is read is either the one specified via command line flags or the one defined as the target repository of the Jenkins X Environment object, whose name too can be passed in via CLI flags.
+
+In case that repository is read out from the environment, then if we are running
+in Kubernetes cluster the Environment object is searched for either in the namespace defined by the current kubeconfig context (if command is executed locally) or is searched for in the namespace of the Pod on which the command is being executed.
+
+In case that command is not executed in Kubernetes and the repository has not been set via command line flags, then the repositoy from which file is read needs to be configured in environment variable: `JX_ENVIRONMENT_GIT_URL`.
+
+The file is either copied to the path specified by the command line flag `--to` or is written under the same path from which it was read into the current working directory.
+
+Notes:
+- The namespace in which the command looks for the environment is either the namespace configured in kubeconfig or the namespace of the pod on which command is executing.
 
 ### Examples
 
@@ -40,8 +54,6 @@ Gets a file from a git repository or environment git repository
       --source-url string   the git source URL of the repository
       --to string           the destination of the file. If not specified defaults to the path
 ```
-
-
 
 ### Source
 

--- a/content/en/v3/develop/reference/jx/gitops/git/get/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/get/_index.md
@@ -19,17 +19,19 @@ Gets a file from a git repository or Jx Environment git repository
 
 ### Details
 
-Copies a file specified by `--file` flag from a Git repository into local file system. The repository from which the file is read is either the one specified via command line flags or the one defined as the target repository of the Jenkins X Environment object, whose name too can be passed in via CLI flags.
+Copies a file specified by `--file` flag from a Git repository into local file system. The repository from which the
+file is read is either the one specified via command line flags or the one defined as the target repository of the
+Jenkins X Environment object, whose name too can be passed in via CLI flags.
 
-In case that repository is read out from the environment, then if we are running
-in Kubernetes cluster the Environment object is searched for either in the namespace defined by the current kubeconfig context (if command is executed locally) or is searched for in the namespace of the Pod on which the command is being executed.
+In case that repository is read out from the environment, then if we are running in Kubernetes cluster the Environment
+object is searched for either in the namespace defined by the current kubeconfig context (if command is executed
+locally) or is searched for in the namespace of the Pod on which the command is being executed.
 
-In case that command is not executed in Kubernetes and the repository has not been set via command line flags, then the repositoy from which file is read needs to be configured in environment variable: `JX_ENVIRONMENT_GIT_URL`.
+In case that command is not executed in Kubernetes and the repository has not been set via command line flags, then the
+repositoy from which file is read needs to be configured in environment variable: `JX_ENVIRONMENT_GIT_URL`.
 
-The file is either copied to the path specified by the command line flag `--to` or is written under the same path from which it was read into the current working directory.
-
-Notes:
-- The namespace in which the command looks for the environment is either the namespace configured in kubeconfig or the namespace of the pod on which command is executing.
+The file is either copied to the path specified by the command line flag `--to` or is written under the same path from
+which it was read into the current working directory.
 
 ### Examples
 

--- a/content/en/v3/develop/reference/jx/gitops/git/merge/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/merge/_index.md
@@ -9,7 +9,7 @@ aliases:
 
 ### Usage
 
-```
+```bash
 jx gitops git merge
 ```
 
@@ -37,9 +37,10 @@ by base branch are included to be merged into the base branch.
   jx-gitops git merge
 
   ```
+  
 ### Options
 
-```
+```text
       --base-branch string       The branch to merge to. If not specified then either $PULL_BASE_REF is used or the first entry in $PULL_REFS is used 
       --base-sha string          The SHA to use on the base branch. Iff not specified then $PULL_BASE_SHA is used or the first entry in $PULL_REFS is used
       --dir string               The directory in which the git repo is checked out (default ".")

--- a/content/en/v3/develop/reference/jx/gitops/git/merge/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/merge/_index.md
@@ -15,7 +15,21 @@ jx gitops git merge
 
 ### Synopsis
 
-Merge a number of SHAs into the HEAD of the main branch
+Merge a number of SHAs into the HEAD of the main branch.
+
+### Details
+
+This command merges a list of commits into a specified branch. If the branch does not exist among local branches, then
+it is first created.
+
+If both `--pull-refs` and `--sha` flags are specified then only those commits specified by `--sha` are merged into the
+base branch.
+
+If `--include-comment` or `--exclude-comment` flags are specified, then `--pull-number` flag needs to be set as well.
+If only one of `--include-comment` or `--exclude-comment`, then only that one is used to filter commits while other is
+ignored. If both are specified, then only those commits which satisfy ``--include-comment` and do not satisfy the
+`--exclude-comment` regex are added. Only those commits which are reachable by from pull request and are not reachable
+by base branch are included to be merged into the base branch.
 
 ### Examples
 
@@ -40,8 +54,6 @@ Merge a number of SHAs into the HEAD of the main branch
       --remote string            The name of the remote (default "origin")
       --sha stringArray          The SHA(s) to merge, if not specified then the value of the env var $PULL_REFS is parsed
 ```
-
-
 
 ### Source
 

--- a/content/en/v3/develop/reference/jx/gitops/git/merge/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/merge/_index.md
@@ -27,7 +27,7 @@ base branch.
 
 If `--include-comment` or `--exclude-comment` flags are specified, then `--pull-number` flag needs to be set as well.
 If only one of `--include-comment` or `--exclude-comment`, then only that one is used to filter commits while other is
-ignored. If both are specified, then only those commits which satisfy ``--include-comment` and do not satisfy the
+ignored. If both are specified, then only those commits which satisfy `--include-comment` and do not satisfy the
 `--exclude-comment` regex are added. Only those commits which are reachable by from pull request and are not reachable
 by base branch are included to be merged into the base branch.
 

--- a/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
@@ -46,8 +46,8 @@ Secret resource provisioned together with `jx-git-operator` in your Kubernetes n
 
 The Git username and email are preferentially determined from `PipelineUser` field from `jx-requirements.yaml`, but if
 they are not available there then default email address `jenkins-x@googlegroups.com` is used (which is the reason why
-you are seeing commits from `pow-devops2020` user made on your repositories). If the username could not be
-determined from `jx-requirements.yaml`, then it is determined from:
+you are seeing commits from `pow-devops2020` user made on your repositories). If the username could not be determined
+from `jx-requirements.yaml`, then it is determined from:
 
 - `GIT_USERNAME` environment variable or
 - `GITHUB_ACTOR` environment variable

--- a/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
@@ -9,7 +9,7 @@ aliases:
 
 ### Usage
 
-```
+```bash
 jx gitops git setup
 ```
 
@@ -25,6 +25,42 @@ This is typically used in a pipeline to ensure git can do commits.
   jx-gitops git setup
 
   ```
+  
+### Details
+
+The `jx gitops git setup` command ensures that we can authenticate with configured Git server by configuring the local
+credentials file in the home directory. This command tries to ensure following things:
+
+- The user can be authenticated with Git provider (for example Github)
+- An email is associated with each automated commit message
+
+These credentials are written to `${HOME}/git/credentials` file, where the `${HOME}` directory is determined as:
+
+- value stored in `XGD_CONFIG_HOME` environment variable or
+- value stored in `HOME` environment variable or
+- value stored in `USERPROFILE` environment variable or
+- as current directory `.`
+
+The credentials are determined by reading out the `jx-requirements.yaml` from the cluster repository and `jx-boot`
+Secret resource provisioned together with `jx-git-operator` in your Kubernetes namespace.
+
+The Git username and email are preferentially determined from `PipelineUser` field from `jx-requirements.yaml`, but if
+they are not available there then default email address `jenkins-x@googlegroups.com` is used (which is the reason why
+you are seeing commits from `pow-devops2020` user made on your repositories). If the username could not be
+determined from `jx-requirements.yaml`, then it is determined from:
+
+- `GIT_USERNAME` environment variable or
+- `GITHUB_ACTOR` environment variable
+- In case that we are running in Kubernetes cluster from `username` field of the `jx-boot` Secret provisioned with
+  `jx-git-operator`
+
+The password for Github user (or a token for the robot account, depending on which you configued) is determined in
+similar fashion. Namely the token is first determined from environment variable `GITHUB_TOKEN`, but if that fails, then
+further determination is dependent on execution environment of the command. Namely if it is running within Github
+actions, then the `GITHUB_TOKEN` environment variable is our last stop. Otherwise if the command is executed within
+Kubernetes cluster, then the secret is determined by reading the `password` field of the `jx-boot` Secret provisioned
+with the `jx-git-operator`.
+
 ### Options
 
 ```
@@ -40,8 +76,6 @@ This is typically used in a pipeline to ensure git can do commits.
       --password string             the git password/token to use. if not specified it is detected from the git operator Secret
       --secret string               the name of the Secret to find the git URL, username and password for creating a git credential if running inside the cluster (default "jx-boot")
 ```
-
-
 
 ### Source
 

--- a/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
@@ -66,9 +66,9 @@ with the `jx-git-operator`.
 ```
       --credentials-file string     The destination of the git credentials file to generate. If not specified uses $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials
   -d, --dir string                  the directory to run the git setup command from
-  -e, --email string                the git user email to use if one is not setup
+  -e, --email string                the git user email to use if one is not setup. Default value is `jenkins-x@googlegroups.com`, if none other is provided
       --fake-in-cluster             for testing: lets you fake running this command inside a kubernetes cluster so that it can create the file: $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials
-      --git-provider string         the git provider URL. If not specified its detected from the git operator Secret or defaults to https://github.com
+      --git-provider string         the git provider URL. If not specified it is detected from the git operator `jx-boot` Secret or defaults to https://github.com
   -h, --help                        help for setup
   -n, --name string                 the git user name to use if one is not setup
       --namespace string            the namespace used to find the git operator secret for the git repository if running in cluster. Defaults to the current namespace

--- a/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/git/setup/_index.md
@@ -29,7 +29,7 @@ This is typically used in a pipeline to ensure git can do commits.
 ### Details
 
 The `jx gitops git setup` command ensures that we can authenticate with configured Git server by configuring the local
-credentials file in the home directory. This command tries to ensure following things:
+credentials file in the home directory. This command tries to ensure the following things:
 
 - The user can be authenticated with Git provider (for example Github)
 - An email is associated with each automated commit message


### PR DESCRIPTION
# Description

I have added more detailed descriptions of what the commands under `jx gitops git` do when they are executed. This should help the users to be more certain that they are using the commands correctly.

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

