### PR TITLE
Fix usage of "on-premises"

### DIFF
--- a/content/en/blog/news/2020-jx-v3-beta.md
+++ b/content/en/blog/news/2020-jx-v3-beta.md
@@ -51,7 +51,7 @@ jx ui
 
 * we now use [helm](https://helm.sh/) (3.x) and [helmfile](https://github.com/roboll/helmfile) along with optionally [kustomize](https://kustomize.io/) in a GitOps style to define and configure both Jenkins X itself, your tools and applications in any namespace
 * support [multi cluster](/v3/admin/guides/multi-cluster/) out of the box so you can keep `Staging` and `Production` in separate clusters to your development cluster where your pipelines run, you create and release immutable container images and other artifacts.
-* to [setup or upgrade](/v3/admin/) Jenkins X we use [terraform](https://www.terraform.io/) to setup your cloud resources on [Azure](/v3/admin/platforms/azure/), [Amazon](/v3/admin/platforms/eks/) or [Google](/v3/admin/platforms/google/) while also supporting on premise, minkube and OpenShift - see the [Admin Guides](/v3/admin/) for more detail
+* to [setup or upgrade](/v3/admin/) Jenkins X we use [terraform](https://www.terraform.io/) to setup your cloud resources on [Azure](/v3/admin/platforms/azure/), [Amazon](/v3/admin/platforms/eks/) or [Google](/v3/admin/platforms/google/) while also supporting on-premises, minkube and OpenShift - see the [Admin Guides](/v3/admin/) for more detail
   * the actual installation of kubernetes resources takes place using the [git operator](/v3/admin/guides/operator/) so it runs reliably inside the cluster itself
 * we default to using [Kubernetes External Secrets](https://github.com/external-secrets/kubernetes-external-secrets) to manage all secrets for Jenkins X itself, development tools and your applications too. 
   * This means we can support various secret backends such as Alibaba Cloud KMS Secret Manager, Amazon Secret Manager, Azure Key Vault, Hashicorp Vault or GCP Secret Manager
@@ -68,7 +68,7 @@ In general Jenkins X 3.x is now much simpler and more flexible. It supports [lot
 
 ### Getting started
 
-If you have never tried [3.x](/v3/about/) before then please follow the [Admin Guide](/v3/admin/) to get Jenkins X installed on your cloud provider, on premise kubernetes cluster or minikube.
+If you have never tried [3.x](/v3/about/) before then please follow the [Admin Guide](/v3/admin/) to get Jenkins X installed on your cloud provider, on-premises kubernetes cluster or minikube.
 
 If you previously tried the 3.x alpha then the [migration instructions are here](/v3/admin/guides/migrate/v3-alpha/).
 

--- a/content/en/blog/news/2020-jx-v3.md
+++ b/content/en/blog/news/2020-jx-v3.md
@@ -45,7 +45,7 @@ Azure support is getting really close; if you'd like to help get it ready [join 
 Also when using your laptop or local kubernetes cluster without terraform we support:
  
 * [Minikube](/v3/admin/platform/minikube/) so you can run Jenkins X on your laptop
-* [On Premise](/v3/admin/platform/on-premise/) so you can use any vanilla kubernetes cluster
+* [On-Premises](/v3/admin/platform/on-premises/) so you can use any vanilla kubernetes cluster
 
 
 We are working on improving the UX of the installation/upgrade; we're hoping to soon have a pure terraform (or Terraform Cloud) way to spin up a Jenkins X installation on a public cloud with a minimum of fuss. We'll hopefully blog about that soon... 

--- a/content/en/blog/news/2020-jx-v3.md
+++ b/content/en/blog/news/2020-jx-v3.md
@@ -45,7 +45,7 @@ Azure support is getting really close; if you'd like to help get it ready [join 
 Also when using your laptop or local kubernetes cluster without terraform we support:
  
 * [Minikube](/v3/admin/platform/minikube/) so you can run Jenkins X on your laptop
-* [On-Premises](/v3/admin/platform/on-premises/) so you can use any vanilla kubernetes cluster
+* [On-Premises](/v3/admin/platforms/on-premises/) so you can use any vanilla kubernetes cluster
 
 
 We are working on improving the UX of the installation/upgrade; we're hoping to soon have a pure terraform (or Terraform Cloud) way to spin up a Jenkins X installation on a public cloud with a minimum of fuss. We'll hopefully blog about that soon... 

--- a/content/en/blog/news/2021-jx-v3-ga.md
+++ b/content/en/blog/news/2021-jx-v3-ga.md
@@ -75,7 +75,7 @@ jx ui
 
 * we now use [helm](https://helm.sh/) (3.x) and [helmfile](https://github.com/roboll/helmfile) along with optionally [kustomize](https://kustomize.io/) in a GitOps style to define and configure both Jenkins X itself, your tools and applications in any namespace
 * support [multi cluster](/v3/admin/guides/multi-cluster/) out of the box so you can keep `Staging` and `Production` in separate clusters to your development cluster where your pipelines run, you create and release immutable container images and other artifacts.
-* to [setup or upgrade](/v3/admin/) Jenkins X we use [terraform](https://www.terraform.io/) to setup your cloud resources on [Azure](/v3/admin/platforms/azure/), [Amazon](/v3/admin/platforms/eks/) or [Google](/v3/admin/platforms/google/) while also supporting on premise, minkube and OpenShift - see the [Admin Guides](/v3/admin/) for more detail
+* to [setup or upgrade](/v3/admin/) Jenkins X we use [terraform](https://www.terraform.io/) to setup your cloud resources on [Azure](/v3/admin/platforms/azure/), [Amazon](/v3/admin/platforms/eks/) or [Google](/v3/admin/platforms/google/) while also supporting on-premises, minkube and OpenShift - see the [Admin Guides](/v3/admin/) for more detail
   * the actual installation of kubernetes resources takes place using the [git operator](/v3/admin/guides/operator/) so it runs reliably inside the cluster itself
 * we default to using [Kubernetes External Secrets](https://github.com/external-secrets/kubernetes-external-secrets) to manage all secrets for Jenkins X itself, development tools and your applications too. 
   * This means we can support various secret backends such as Alibaba Cloud KMS Secret Manager, Amazon Secret Manager, Azure Key Vault, Hashicorp Vault or GCP Secret Manager
@@ -94,7 +94,7 @@ In general Jenkins X 3.x is now much simpler and more flexible. It supports [lot
 
 ### Getting started
 
-If you have never tried [3.x](/v3/about/) before then please follow the [Admin Guide](/v3/admin/) to get Jenkins X installed on your cloud provider, on premise kubernetes cluster or minikube.
+If you have never tried [3.x](/v3/about/) before then please follow the [Admin Guide](/v3/admin/) to get Jenkins X installed on your cloud provider, on-premises kubernetes cluster or minikube.
 
 If you previously tried the 3.x alpha then the [migration instructions are here](/v3/admin/guides/migrate/v3-alpha/).
 

--- a/content/en/docs/install-setup/boot/clouds/_index.md
+++ b/content/en/docs/install-setup/boot/clouds/_index.md
@@ -12,7 +12,7 @@ aliases:
   - /docs/install-setup/installing/boot/clouds/
 ---
 
-Jenkins X is designed to work on any Kubernetes cluster; whether on premise, hybrid or public cloud.
+Jenkins X is designed to work on any Kubernetes cluster; whether on-premises, hybrid or public cloud.
 
 However, if you try doing any significant work with Kubernetes particularly with things like storage, networking, ingress, TLS, certificates, DNS,secrets - you will find that things can be different on different cloud providers.
 

--- a/content/en/docs/install-setup/boot/clouds/on-premises.md
+++ b/content/en/docs/install-setup/boot/clouds/on-premises.md
@@ -1,16 +1,17 @@
 ---
-title: On Premise
-linktitle: On Premise
-description: Using Boot On Premise
+title: On-Premises
+linktitle: On-Premises
+description: Using Boot On-Premises
 date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-02-01
 weight: 40
 aliases:
+  - /docs/install-setup/boot/clouds/on-premise/
   - /docs/install-setup/installing/boot/clouds/on-premise/
 ---
 
-On premise kubernetes clusters tend to differ wildly so its hard for us to know your Jenkins X installation will totally work on any cluster given we typically rely on things like persistence, ingress, storage.
+On-premises kubernetes clusters tend to differ wildly so its hard for us to know your Jenkins X installation will totally work on any cluster given we typically rely on things like persistence, ingress, storage.
 
 Here are some recommendations to hopefully get you started. If you hit any issues please [join our community](/community/) we can hopefully help you.
 
@@ -25,13 +26,13 @@ clusterConfig:
 
 ### Ingress
 
-If you don't have a real ingress solution for your on premise cluster you can start off using the `nginx-controller` and the IP address of your api server.
+If you don't have a real ingress solution for your on-premises cluster you can start off using the `nginx-controller` and the IP address of your api server.
 
 You can set `ingress.domain` to be `1.2.3.4.nip.io` where `1.2.3.4` is the IP address of your ingress service.
 
 By default boot will try to recreate the `ingress.domain` by discovering the IP address on the nginx controller service - which is commonly generated dynamically on the public clouds.
 
-If you are on premise and using a hard coded IP address for ingress you may want to set this on your `jx-requirements.yml`
+If you are on-premises and using a hard coded IP address for ingress you may want to set this on your `jx-requirements.yml`
 
 ```yaml
 clusterConfig:

--- a/content/en/docs/resources/faq/setup.md
+++ b/content/en/docs/resources/faq/setup.md
@@ -100,4 +100,4 @@ times out.
 
 Jenkins X installs `nginx` which has a `LoadBalancer` kubernetes `Service`. But the underlying kubernetes platform needs to implement the load balancing network and infrastructure. This comes OOTB on all public clouds. 
  
-On premise you need to install something like [MetalLB](https://metallb.universe.tf/)
+On-premises you need to install something like [MetalLB](https://metallb.universe.tf/)

--- a/content/en/docs/resources/guides/managing-jx/old/install-on-cluster.md
+++ b/content/en/docs/resources/guides/managing-jx/old/install-on-cluster.md
@@ -164,14 +164,14 @@ If you know the provider, you can specify the provider on the command line. e.g.
 jx install --provider=aws
 ```
 
-## Installing Jenkins X on premises
+## Installing Jenkins X on-premises
 
 __Prerequisits__
 - Kubernetes > 1.8
 - RBAC enabled
 - A default cluster [dynamic storage class](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) for provisioning persistent volumes.
 
-When using an on premise Kubernetes cluster, you can use this command line:
+When using an on-premises Kubernetes cluster, you can use this command line:
 
 ```sh
 jx install --provider=kubernetes --on-premise
@@ -185,7 +185,7 @@ If you wish to use a different external IP address, you can use:
 jx install --provider=kubernetes --external-ip 1.2.3.4
 ```
 
-Otherwise, the `jx install` will try and wait for the Ingress Controllers `Service.Status.LoadBalancer.Ingress` to resolve to an IP address - which can fail on premise.
+Otherwise, the `jx install` will try and wait for the Ingress Controllers `Service.Status.LoadBalancer.Ingress` to resolve to an IP address - which can fail on-premises.
 
 If you already have an ingress controller installed, then try:
 
@@ -232,7 +232,7 @@ Create `ClusterImagePolicies` on IBM Cloud Private version 3.1.0 and set the fol
 
 Specify the following two `jx install` parameters with the command line or when prompted by the IBM Cloud Private provider:
 - The `domain=''` parameter is the domain to expose ingress endpoints, for example, `jenkinsx.io`.
-- The `external-ip=''` parameter is the external IP that is used to access ingress endpoints from outside the Kubernetes cluster and for bare metal on premise clusters.
+- The `external-ip=''` parameter is the external IP that is used to access ingress endpoints from outside the Kubernetes cluster and for bare metal on-premises clusters.
 
 If you don't specify these parameters, then the `jx install --provider=icp` command first prompts you to enter the `external-ip` parameter. Next, it prompts you to enter the `domain` parameter and offers you the `<external-ip>.nip.io` default value. After you enter these values, an ingress endpoint becomes available at `http://jenkins.jx.<your cluster IP>.nip.io`.
 

--- a/content/en/v3/admin/platforms/on-premises/_index.md
+++ b/content/en/v3/admin/platforms/on-premises/_index.md
@@ -1,6 +1,6 @@
 ---
-title: On Premise
-linktitle:  On Premise
+title: On-Premises
+linktitle:  On-Premises
 type: docs
 description: Setup Jenkins X on vanilla Kubernetes  
 date: 2017-02-01
@@ -9,6 +9,7 @@ lastmod: 2020-02-21
 weight: 150
 aliases:
   - /v3/admin/platform/on-premise
+  - /v3/admin/platforms/on-premise
 ---
 
 ---
@@ -18,26 +19,26 @@ Ensure you are logged into GitHub else you will get a 404 error when clicking th
 
 ---
 
-## On Premise Kubernetes
+## On-Premises Kubernetes
 
 If you are using kubernetes we highly recommend you use one of the [managed cloud providers](/v3/#administration) as this comes with lots of additional features like:
 
 * container registries and bucket storage
 * IAM and workload identity (e.g. so kubernetes Service Accounts can be assigned roles to be able to read/write to certain buckets or container registries) 
 
-However sometimes you need to run kubernetes on your premise. Longer term we hope the cloud providers can run their managed kubernetes and associated infrastructure on your premise too so you get to reuse the same storage + IAM anywhere. But until then, this guide is intended to get you started installing Jenkins X on a vanilla kubernetes cluster on premise.
+However sometimes you need to run kubernetes on your premises. Longer term we hope the cloud providers can run their managed kubernetes and associated infrastructure on your premises too so you get to reuse the same storage + IAM anywhere. But until then, this guide is intended to get you started installing Jenkins X on a vanilla kubernetes cluster on-premises.
 
 Here are some detailed [instructions](https://007ba7.us/howto/jx-install/) on getting JX running in a Lab Environment.
 
 ### Prerequisites
 
-The following are the prerequisites of your on-premise kubernetes cluster:
+The following are the prerequisites of your on-premises kubernetes cluster:
 
 * [Download and install the jx 3.x binary](/v3/guides/jx3/)
 
 #### Kubernetes cluster
 
-We obviously need a working kubernetes cluster. There are many approaches to [setting up on premise clusters](https://kubernetes.io/docs/setup/production-environment/tools/) obviously the easiest approach is to use the [cloud](/v3/#administration).
+We obviously need a working kubernetes cluster. There are many approaches to [setting up on-premises clusters](https://kubernetes.io/docs/setup/production-environment/tools/) obviously the easiest approach is to use the [cloud](/v3/#administration).
 
 If you are going the bare metal route you could try [these instructions](https://007ba7.us/howto/k8s-install/)
  
@@ -58,7 +59,7 @@ To use Jenkins X we need ingress to work. This means being able to create a kube
 
 Jenkins X installs `nginx` which has a `LoadBalancer` kubernetes `Service` to implement ingress. But the underlying kubernetes platform needs to implement the load balancing network and infrastructure. This comes out of the box on all public clouds.
  
-With an on-premise kubernetes cluster you need to install something like [MetalLB](https://metallb.universe.tf/)
+With an on-premises kubernetes cluster you need to install something like [MetalLB](https://metallb.universe.tf/)
 
 If you are on bare metal you could try [these instructions](https://007ba7.us/howto/metallb/)
 
@@ -70,7 +71,7 @@ You may find [these instructions useful](https://007ba7.us/howto/nfs-storage/)
 
 ### Getting Started
 
-This is our current recommended quickstart for on premise kubernetes:
+This is our current recommended quickstart for on-premises kubernetes:
 
 *  <a href="https://github.com/jx3-gitops-repositories/jx3-kubernetes/generate" target="github" class="btn bg-primary text-light">Create the cluster Git Repository</a> based on the [jx3-gitops-repositories/jx3-kubernetes](https://github.com/jx3-gitops-repositories/jx3-kubernetes/generate) template
 

--- a/content/en/v3/admin/platforms/on-premises/vault.md
+++ b/content/en/v3/admin/platforms/on-premises/vault.md
@@ -2,17 +2,19 @@
 title: Vault
 linktitle: Vault
 type: docs
-description: How to use an on premise kubernetes cluster with vault
+description: How to use an on-premises kubernetes cluster with vault
 weight: 100
+aliases:
+  - /v3/admin/platforms/on-premise/vault/
 ---
 
 **NOTE** that in the following instructions it is left to the user to manage, backup and restore the vault installation once it has been installed. 
 
-For production workloads [we recommend you use a cloud provider secret store](/v3/devops/patterns/prefer_cloud_over_kube/) or [Vault as a service](https://www.hashicorp.com/resources/running-vault-as-a-service-on-hashicorp-cloud-platform). Managing on premise vault instances is undifferentiated heavy lifting that should be outsourced to a cloud provider if you can. 
+For production workloads [we recommend you use a cloud provider secret store](/v3/devops/patterns/prefer_cloud_over_kube/) or [Vault as a service](https://www.hashicorp.com/resources/running-vault-as-a-service-on-hashicorp-cloud-platform). Managing on-premises vault instances is undifferentiated heavy lifting that should be outsourced to a cloud provider if you can. 
 
 ### Prerequisites
 
-The prerequisites are the [same as regular on premise kubernetes](/v3/admin/platforms/on-premise/#prerequisites) around having a kubernetes cluster with ingress and storage
+The prerequisites are the [same as regular on-premises kubernetes](/v3/admin/platforms/on-premises/#prerequisites) around having a kubernetes cluster with ingress and storage
 
 The difference is for vault:
 

--- a/content/en/v3/admin/platforms/on-premises/webhooks.md
+++ b/content/en/v3/admin/platforms/on-premises/webhooks.md
@@ -2,8 +2,10 @@
 title: Enable WebHooks
 linktitle: Enable WebHooks
 type: docs
-description: How to enable webhooks if you are on premise
+description: How to enable webhooks if you are on-premises
 weight: 100
+aliases:
+  - /v3/admin/platforms/on-premise/webhooks/
 ---
 
 If your cluster is not accessible on the internet and you can't open a firewall to allow services like GitHub to access your ingress then you will need to enable webhooks as follows:

--- a/content/en/v3/admin/setup/config/storage.md
+++ b/content/en/v3/admin/setup/config/storage.md
@@ -11,4 +11,4 @@ By storage we mean cloud storage (e.g. bucket storage for logs). Any [chart you 
         
 If you are using a [cloud platform](/v3/admin/platforms/) and terraform then your storage will be configured OOTB.
 
-If you are [on premise](/v3/admin/platforms/) and have installed something like [minio](https://min.io/) on your cluster then you can configure the `storage` section of your [jx-requirements.yml](https://github.com/jenkins-x/jx-api/blob/master/docs/config.md#requirements) file to map to minio bucket URLs
+If you are [on-premises](/v3/admin/platforms/) and have installed something like [minio](https://min.io/) on your cluster then you can configure the `storage` section of your [jx-requirements.yml](https://github.com/jenkins-x/jx-api/blob/master/docs/config.md#requirements) file to map to minio bucket URLs

--- a/content/en/v3/admin/setup/ingress/default.md
+++ b/content/en/v3/admin/setup/ingress/default.md
@@ -24,6 +24,6 @@ where `1.2.3.4` is your external IP address of your nginx `LoadBalancer` service
 
 Incidentally when you use a public cloud and create a [kubernetes service of type LoadBalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/) it is automatically associated with a public IP.
 
-Note that if you are [on premise](/v3/admin/platforms/on-premise/) then the `LoadBalancer` service probably won't automatically get resolved to an external IP. So you will probably need to setup a load balancer like [MetalLB](https://metallb.universe.tf/)
+Note that if you are [on-premises](/v3/admin/platforms/on-premises/) then the `LoadBalancer` service probably won't automatically get resolved to an external IP. So you will probably need to setup a load balancer like [MetalLB](https://metallb.universe.tf/)
 
 

--- a/content/en/v3/admin/setup/operator/_index.md
+++ b/content/en/v3/admin/setup/operator/_index.md
@@ -104,7 +104,7 @@ Which will wait for a running Job to display.
 
 ## Insecure git repositories 
 
-If you are using an on premise git repository you may need to configure git in the git operator and boot job to support insecure git repositories via a `git config` command or two.
+If you are using an on-premises git repository you may need to configure git in the git operator and boot job to support insecure git repositories via a `git config` command or two.
 
 When installing the git operator you can pass in any git configuration commands via the `--setup` argument. You can supply multiple of these arguments if you need them.
 

--- a/content/en/v3/admin/setup/secrets/vault.md
+++ b/content/en/v3/admin/setup/secrets/vault.md
@@ -14,7 +14,7 @@ aliases:
 If you are using Terraform with one of the [Cloud Providers](/v3/admin/) then your Vault will be installed automatically via Terraform.
 
 
-Otherwise please see the [On Premise Vault Install Guide](/v3/admin/platforms/on-premise/vault/)
+Otherwise please see the [On-Premises Vault Install Guide](/v3/admin/platforms/on-premises/vault/)
 
 
 whichever apporoach take you should have:

--- a/content/en/v3/admin/setup/upgrades/migrations.md
+++ b/content/en/v3/admin/setup/upgrades/migrations.md
@@ -18,7 +18,7 @@ not possible or practical
 NB: These steps are only relevant if you are using Hashicorp Vault as secret storage within `jx`. Ignore for all other secret stores
 
 v0.0.969 introduced a change to remove Hashicorp Vault from `jx` control and become an explicit cluster dependency
-installed either via Terraform (for cloud environments) or Helm (for on-premise). The reasoning behind this is to reduce
+installed either via Terraform (for cloud environments) or Helm (for on-premises). The reasoning behind this is to reduce
 cyclic complexity within `jx` where the platform requires secrets and the `jx` platform is also responsible for provisioning
 where to store these secrets.
 

--- a/content/en/v3/admin/troubleshooting/webhooks.md
+++ b/content/en/v3/admin/troubleshooting/webhooks.md
@@ -56,7 +56,7 @@ Then click the `GIT URL` link for your repository.
 
 Now look at the **Webbooks** page to see if your git provider could send webhooks to your hook endpoint. On GitHub thats **Settings** ->  **Webhooks**
 
-It could be your git provider can't see public ingress endpoint? If thats the case you may need to look at setting up a tunnel via something like [ngrok to enable on premise webhooks](/v3/admin/platforms/on-premise/#enable-webhooks) 
+It could be your git provider can't see public ingress endpoint? If thats the case you may need to look at setting up a tunnel via something like [ngrok to enable on-premises webhooks](/v3/admin/platforms/on-premises/#enable-webhooks) 
 
 ### AWS specific issues
 

--- a/content/en/v3/develop/faq/config/ingress.md
+++ b/content/en/v3/develop/faq/config/ingress.md
@@ -106,4 +106,4 @@ See [How to diagnose webhooks](/v3/admin/troubleshooting/webhooks/)
 
 If you are running on your laptop or in a private cluster you won't be able to use webhooks on your git provider to trigger pipelines.
 
-A workaround is to use [use something like ngrok to enable webhooks](/v3/admin/platforms/on-premise/webhooks/)
+A workaround is to use [use something like ngrok to enable webhooks](/v3/admin/platforms/on-premises/webhooks/)

--- a/content/en/v3/develop/reference/jx/gitops/webhook/update/_index.md
+++ b/content/en/v3/develop/reference/jx/gitops/webhook/update/_index.md
@@ -26,7 +26,7 @@ Updates the webhooks for all the source repositories optionally filtering by own
   # only update the webhooks for a given owner
   jx-gitops update --org=mycorp
   
-  # use a custom hook webhook endpoint (e.g. if you are on premise using node ports or something)
+  # use a custom hook webhook endpoint (e.g. if you are on-premises using node ports or something)
   jx-gitops update --endpoint http://mything.com
 
   ```

--- a/content/zh/v3/admin/troubleshooting/webhooks.md
+++ b/content/zh/v3/admin/troubleshooting/webhooks.md
@@ -55,7 +55,7 @@ kubectl get environments
 
 打开你的 git 提供商的 **Webbooks** 页面， 查看发送到 hook 地址的请求是否成功。对于 GitHub，你可以在 **Settings** ->  **Webhooks** 这里找到。
 
-如果你的 git 无法访问 ingress 地址的话，你可以设置一个转发通道。请查看[借助 ngrok 使用 webhooks](/v3/admin/platforms/on-premise/#enable-webhooks) 
+如果你的 git 无法访问 ingress 地址的话，你可以设置一个转发通道。请查看[借助 ngrok 使用 webhooks](/v3/admin/platforms/on-premises/#enable-webhooks) 
 
 ### AWS 相关的问题
 

--- a/layouts/shortcodes/admincards.html
+++ b/layouts/shortcodes/admincards.html
@@ -39,8 +39,8 @@
     <div class="card text-center align-center h-100">
       <div class="card-body align-center">
         <p class="card-text text-center">
-          <a href="/v3/admin/platforms/on-premise/" title="setup Jenkins X on any Kubernetes cluster without cloud resources">
-            <img alt="On Premise" src="/images/logo/k8s.svg" style="float: none;"/>
+          <a href="/v3/admin/platforms/on-premises/" title="setup Jenkins X on any Kubernetes cluster without cloud resources">
+            <img alt="On-Premises" src="/images/logo/k8s.svg" style="float: none;"/>
           </a>
         </p>
       </div>


### PR DESCRIPTION
# Description

A _premise_ is "[a proposition […] supposed or proved as a basis of argument or inference](https://www.merriam-webster.com/dictionary/premise)", while _premises_ refers to "[a tract of land with the buildings thereon](https://www.merriam-webster.com/dictionary/premises)".

See also: [re:Invent 2018 premises/premise supercut](https://www.youtube.com/watch?v=RWHocP0AzMc)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.