### PR TITLE
fix: ensure the osiris helmfile is valid

### DIFF
--- a/content/en/v3/admin/guides/preview-environments/_index.md
+++ b/content/en/v3/admin/guides/preview-environments/_index.md
@@ -36,6 +36,7 @@ The second step is to create the `helmfiles/osiris-system/helmfile.yaml` file, w
 namespace: osiris-system
 releases:
 - chart: osiris/osiris
+  name: osiris
 ```
 
 Commit and push these changes, and after a few minutes you should see a few osiris pods running in the `osiris-system` namespace:


### PR DESCRIPTION
the release name is mandatory, so let's make sure that people following this admin guide will end up with a valid helmfile.yaml