### PR TITLE
docs: Fix typo in title of Troubleshooting page

### DIFF
--- a/content/en/v3/develop/faq/issues.md
+++ b/content/en/v3/develop/faq/issues.md
@@ -1,6 +1,6 @@
 ---
-title: Troublehshooting
-linktitle: Troublehshooting
+title: Troubleshooting
+linktitle: Troubleshooting
 type: docs
 description: Questions on common issues folks hit using the cloud, kubernetes and Jenkins X
 weight: 400


### PR DESCRIPTION
Fixes a typo in the issues.md file, where the title is "Troublehshooting" instead of "Troubleshooting".
