### PR TITLE
Fix broken config

### DIFF
--- a/content/en/v3/admin/guides/lighthouse-webui/_index.md
+++ b/content/en/v3/admin/guides/lighthouse-webui/_index.md
@@ -17,7 +17,7 @@ Please follow the usual [getting started guide for boot and helm 3](/v3/admin/pl
 Then, open the `helmfiles/jx/helmfile.yaml` file located in your development environment git repository, and add the following content under the `releases` section:
 
 ```yaml 
-- chart: jx3/lighthouse-webui-plugin
+- chart: jxgh/lighthouse-webui-plugin
   name: lighthouse-webui-plugin
 ```
 
@@ -28,7 +28,7 @@ namespace: jx
 repositories:
 - ...
 releases:
-- chart: jx3/lighthouse-webui-plugin
+- chart: jxgh/lighthouse-webui-plugin
   name: lighthouse-webui-plugin
 - chart: ...
 ```


### PR DESCRIPTION
ori failed with 
```
error: failed to process helmfile helmfiles/jx/helmfile.yaml: failed to resolve helmfile {helmfiles/jx/helmfile.yaml ../../}: failed to match prefix jx3 with repositories from versionstream : no matching repository for for prefix jx3
make[1]: *** [versionStream/src/Makefile.mk:114: fetch] Error 1
make[1]: Leaving directory '/workspace/source'
error: failed to regenerate: failed to regenerate phase 1: failed to run 'make regen-phase-1' command in directory '.', output: ''
make: *** [versionStream/src/Makefile.mk:241: regen-check] Error 1
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

