### PR TITLE
docs: add virtualbox prerequisite

### DIFF
--- a/content/en/v3/admin/platforms/minikube/_index.md
+++ b/content/en/v3/admin/platforms/minikube/_index.md
@@ -24,6 +24,8 @@ This guide will walk you though how to setup Jenkins X on your laptop using [min
 
 * [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
 
+* [Install virtualbox](https://www.virtualbox.org/wiki/Downloads)
+
 NOTE:- User of windows 10 home (Hyper-V not supported). To install Minikube consider Docker as driver(docker should be pre-installed)
        instead of virtualBox driver. Use command "minikube start --driver=docker".
 


### PR DESCRIPTION
# Description

Without virtualbox, `minikube --vm=true` fails.

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

