### PR TITLE
fix: add links to jx3-eks-asm template

### DIFF
--- a/content/en/v3/admin/platforms/eks/_index.md
+++ b/content/en/v3/admin/platforms/eks/_index.md
@@ -28,66 +28,62 @@ aliases:
 
 ---
 
-### EKS + Terraform + Vault + Github
+### EKS + Terraform + Vault/ASM + Github
 
 This is our current recommended quickstart for EKS:
 
 Note: remember to create the Git repositories below in your Git Organization rather than your personal Git account else this will lead to issues with ChatOps and automated registering of webhooks.
 
+- <a href="https://github.com/jx3-gitops-repositories/jx3-terraform-eks/generate" target="github" class="btn bg-primary text-light">Create Git Repository for <b>Infrastructure</b></a> based on the [jx3-gitops-repositories/jx3-terraform-eks](https://github.com/jx3-gitops-repositories/jx3-terraform-eks)
 
+  - if the above button does not work then please [Login to GitHub](https://github.com/login) first and then retry the button
 
-*  <a href="https://github.com/jx3-gitops-repositories/jx3-terraform-eks/generate" target="github" class="btn bg-primary text-light">Create Git Repository for <b>Infrastructure</b></a> based on the [jx3-gitops-repositories/jx3-terraform-eks](https://github.com/jx3-gitops-repositories/jx3-terraform-eks)  
+- Choose the cluster git repository based on the secrets backend
 
-    * if the above button does not work then please [Login to GitHub](https://github.com/login) first and then retry the button
+  - <a href="https://github.com/jx3-gitops-repositories/jx3-eks-vault/generate"  target="github-cluster" class="btn bg-primary text-light">Create Git Repository for Jenkins X <b>Cluster</b></a> based on the [jx3-gitops-repositories/jx3-eks-vault](https://github.com/jx3-gitops-repositories/jx3-eks-vault)
 
+  - <a href="https://github.com/jx3-gitops-repositories/jx3-eks-asm/generate"  target="github-cluster" class="btn bg-primary text-light">Create Git Repository for Jenkins X <b>Cluster</b></a> based on the [jx3-gitops-repositories/jx3-eks-asm](https://github.com/jx3-gitops-repositories/jx3-eks-asm)
 
+- Install <a href="https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform">terraform CLI</a>
 
-* <a href="https://github.com/jx3-gitops-repositories/jx3-eks-vault/generate"  target="github-cluster" class="btn bg-primary text-light">Create Git Repository for Jenkins X <b>Cluster</b></a> based on the [jx3-gitops-repositories/jx3-eks-vault](https://github.com/jx3-gitops-repositories/jx3-eks-vault)  
+- Install <a href="https://github.com/jenkins-x/jx-cli/releases">jx CLI </a>
 
+- For AWS SSO ensure you have installed AWSCLI version 2 - [see here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html). You must then configure it to use Named Profiles - [see here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 
-* Install <a href="https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform">terraform CLI</a>
+- <a href="https://github.com/settings/tokens/new?scopes=repo,read:user,read:org,user:email,admin:repo_hook,write:packages,read:packages,write:discussion,workflow" target="github-token" class="btn bg-primary text-light">Create Git Token for the Bot user </a>
 
-* Install <a href="https://github.com/jenkins-x/jx-cli/releases">jx CLI </a>
-
-* For AWS SSO ensure you have installed AWSCLI version 2 - [see here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html). You must then configure it to use Named Profiles - [see here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
-
-* <a href="https://github.com/settings/tokens/new?scopes=repo,read:user,read:org,user:email,admin:repo_hook,write:packages,read:packages,write:discussion,workflow" target="github-token" class="btn bg-primary text-light">Create Git Token for the Bot user </a>
-
-* Override the variable defaults in the Infrastructure repository. (E.g, edit variables.tf, set TF_VAR_ environment variables, or pass the values on the terraform command line.)
+- Override the variable defaults in the Infrastructure repository. (E.g, edit variables.tf, set TF*VAR* environment variables, or pass the values on the terraform command line.)
 
   - cluster_version: Kubernetes version for the EKS cluster. (should be 1.20 at the moment)
   - region: AWS region code for the AWS region to create the cluster in.
   - jx_git_url: URL of the Cluster repository.
   - jx_bot_username: The username of the git bot user
 
-* commit and push any changes to your Infrastructure git repository:
+- commit and push any changes to your Infrastructure git repository:
 
       git commit -a -m "fix: configure cluster repository and project"
       git push
 
-* Define an environment variable to pass the bot token into Terraform:
+- Define an environment variable to pass the bot token into Terraform:
 
       export TF_VAR_jx_bot_token=my-bot-token
 
-* Now, initialise, plan and apply Terraform:
+- Now, initialise, plan and apply Terraform:
 
       terraform init
       terraform plan
       terraform apply
 
-* Tail the Jenkins X installation logs
+- Tail the Jenkins X installation logs
 
-    $(terraform output follow_install_logs)
+  $(terraform output follow_install_logs)
 
+- Once finished you can now move into the Jenkins X Developer namespace
 
-* Once finished you can now move into the Jenkins X Developer namespace
+  jx ns jx
 
-    jx ns jx
+- and create or import your applications
 
-* and create or import your applications
-
-*  <a href="/v3/develop/create-project/" class="btn bg-primary text-light">Create or import projects</a>
-
-
+- <a href="/v3/develop/create-project/" class="btn bg-primary text-light">Create or import projects</a>
 
 For more details on how to install Jenkins X on AWS EKS see [Github repository for Jenkins X Terraform module for EKS](https://github.com/jx3-gitops-repositories/jx3-terraform-eks#prerequisites)

--- a/content/en/v3/develop/ui/slack.md
+++ b/content/en/v3/develop/ui/slack.md
@@ -2,7 +2,7 @@
 title: Slack
 linktitle: Slack
 type: docs
-description: Slack bot for Jenkins X 
+description: Slack bot for Jenkins X
 weight: 200
 ---
 
@@ -10,43 +10,43 @@ Many of us use chat to keep in touch with the developers and tools we work with.
 
 To get [slack](https://www.slack.com/) notifications of pipelines you can use the [jx-slack](https://github.com/jenkins-x-plugins/jx-slack) plugin.
 
-## Creating the slack app 
+## Creating the slack app
 
 Before you can install the [jx-slack](https://github.com/jenkins-x-plugins/jx-slack) plugin you need to create a Slack app.
 
-* [create a new slack app](https://api.slack.com/apps?new_app=1) and fill in the details of the application name and associate it with the slack workspace you wish to use
-* navigate to the **Features** / **OAuth & Permissions** page on the slack app site
+- [create a new slack app](https://api.slack.com/apps?new_app=1) and fill in the details of the application name and associate it with the slack workspace you wish to use
+- navigate to the **Features** / **OAuth & Permissions** page on the slack app site
 
 <img src="/images/slack/slack-oauth-page.png" class="img-thumbnail" width="239" height="573">
 
-* add the Scope **chat:write** to your bot so it can post messages to your slack workspace
-* find your **Bot User OAuth Access Token** which should start with **xoxb-** you will need it later...
-* invite the slack app you have created into whatever channels you want it to notify. e.g. inside the channel you can type `@` and start typing the slack app name to send it a message which will get Slack to prompt you to invite the bot user to the room.                                                                                    
+- add the Scope **chat:write** to your bot so it can post messages to your slack workspace
+- find your **Bot User OAuth Access Token** which should start with **xoxb-** you will need it later...
+- invite the slack app you have created into whatever channels you want it to notify. e.g. inside the channel you can type `@` and start typing the slack app name to send it a message which will get Slack to prompt you to invite the bot user to the room.
 
 ## Installing
 
 To install the [jx-slack](https://github.com/jenkins-x-plugins/jx-slack) plugin add the following to your `helmfiles/jx/helmfile.yaml` file in your dev cluster git repository in the `releases:` section:
 
-```yaml 
+```yaml
 - chart: jxgh/jx-slack
   name: jx-slack
   values:
-  - jx-values.yaml
+    - jx-values.yaml
 ```
 
 Once you have pushed the change to git and your [boot job has retriggered](/v3/about/how-it-works/#boot-job) (you can view this via `jx admin log`) you should see the `jx-slack` secret show up as being missing:
 
-```bash 
-jx secret verify 
+```bash
+jx secret verify
 ```
 
 You can populate your slack bot token via the following. **Note** that if you are using vault [you need to run the port forward first](/v3/admin/setup/secrets/vault/#using-vault):
 
-```bash 
+```bash
 jx secret edit -f jx-slack
 ```
 
-Enter the  **Bot User OAuth Access Token** you found in the [above steps](#creating-the-slack-app) which should start with **xoxb-** 
+Enter the **Bot User OAuth Access Token** you found in the [above steps](#creating-the-slack-app) which should start with **xoxb-**
 
 In a few seconds time you should see the `Secret` show up with the token populated...
 
@@ -66,49 +66,50 @@ In your dev cluster repository the `.jx/gitops/source-config.yaml` file (see the
 
 You can configure the [slack](https://github.com/jenkins-x/jx-gitops/blob/master/docs/config.md#gitops.jenkins-x.io/v1alpha1.SlackNotify) configuration either globally, for a group of repositories or for a single repository.
 
-You can use overriding: so have good global or group based defaults then override on a per repository basis where required. 
+You can use overriding: so have good global or group based defaults then override on a per repository basis where required.
 
-### Filters 
+### Filters
 
-You can change the notification filters at any level (global, group or repository) to let you get the right level of notifications you need. 
+You can change the notification filters at any level (global, group or repository) to let you get the right level of notifications you need.
 
 Its common with chat to be too noisy; so you probably only need to be notified on a subset of events.
 
 e.g. a good default is only be notified for releases only (so ignoring Pull Requests) and only for failures or the first success after a failure. This can be done via the `kind` and `pipeline` filters:
 
-```yaml 
+```yaml
 slack:
-  channel: '#jenkins-x-pipelines'
+  channel: "#jenkins-x-pipelines"
   kind: failureOrNextSuccess
   pipeline: release
 ```
 
 kind values and their behaviors are:
-* `""`: no notifications
-* never: never notify - no notifications
-* always: always send a notification
-* failure: notify only failures
-* failureOrNextSuccess: notify only failures or first success after failure
-* success: notify only on success
+
+- `""`: no notifications
+- never: never notify - no notifications
+- always: always send a notification
+- failure: notify only failures
+- failureOrNextSuccess: notify only failures or first success after failure
+- success: notify only on success
 
 pipeline values and their behaviors are:
-* `""`: no notifications
-* all: notify on all pipelines
-* release: only notify on release pipelines
-* pullRequest: only notify on pullRequest pipelines
+
+- `""`: no notifications
+- all: notify on all pipelines
+- release: only notify on release pipelines
+- pullRequest: only notify on pullRequest pipelines
 
 You can configure the `channel` globally or for different groups or repositories differently too. You can also filter by `branch`, pipeline `context` or `pullRequestLabel`.
-     
-## Example 
+
+## Example
 
 Here's an example of some messages sent to the channel for a repository. In this case its our BDD tests on the version stream.
 
 As you can see a few tests fail then we get a successful pipeline.
 
-You'll notice the links on the git owner, repository, and build number all resolve to links to your git provider or the associated pipeline page in the [Pipeline Visualiser](/v3/develop/ui/dashboard/) 
+You'll notice the links on the git owner, repository, and build number all resolve to links to your git provider or the associated pipeline page in the [Pipeline Visualiser](/v3/develop/ui/dashboard/)
 
 <img src="/images/slack/slack-bot.png" class="img-thumbnail" width="542" height="224">
-
 
 ## Other slack bots
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

# Description
For end users who dont use vault, but use aws secrets manager, we dont have any mention of the jx3-eks-asm template repo which should be used as a starting point for creating the cluster git repo.

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

