### PR TITLE
fix: use shallow clone for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,9 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
+	shallow = true
 
 [submodule "content/en/community/labs/enhancements"]
 	path = content/en/community/labs/enhancements
 	url = https://github.com/jenkins-x/enhancements.git
+	shallow = true


### PR DESCRIPTION

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

