### PR TITLE
fix (external-vault): instructions how-to proxy jx-secret to external vault

### DIFF
--- a/content/en/v3/admin/setup/secrets/vault.md
+++ b/content/en/v3/admin/setup/secrets/vault.md
@@ -93,7 +93,7 @@ export JX_VAULT_ROLE=jx-vault
 export EXTERNAL_VAULT=true
 ```
 
-Run `jx-secret` as you nomrally would:
+Run `jx-secret` as you normally would:
 ```bash
 jx secret edit -i
 ```


### PR DESCRIPTION

# Description

add instructions how-to proxy jx-secret traffic through the cluster.  This allows users to use the `jx secret` command locally, while the traffic and vault access is taken care of by the cluster.

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

