### PR TITLE
fix: Typo in help command

### DIFF
--- a/content/en/v3/admin/setup/jx3/_index.md
+++ b/content/en/v3/admin/setup/jx3/_index.md
@@ -46,7 +46,7 @@ jx version
 or 
 
 ```shell 
-jx help 
+jx --help 
 ```
 
 For more detail see the [Command Line Reference Guide](/v3/develop/reference/jx/) 


### PR DESCRIPTION
Simple typo in the doc