### PR TITLE
fix: new icons in /community route

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -175,17 +175,17 @@ no = 'Sorry to hear that. Please <a href="https://github.com/jenkins-x/jx-docs/i
 [[params.links.user]]
 	name = "Youtube"
 	url = "https://www.youtube.com/channel/UCN2kblPjXKMcjjVYmwvquvg"
-	icon = "fa fa-youtube"
+	icon = "fab fa-youtube"
 	desc = "Subscribe to the youtube Channel"
 [[params.links.user]]
 	name = "Github"
 	url = "https://github.com/jenkins-x/jx"
-	icon = "fa fa-github"
+	icon = "fab fa-github"
 	desc = "Development takes place here!"
 [[params.links.user]]
 	name = "Contribute"
 	url = "https://jenkins-x.io/community/documentation/"
-	icon = "fa fa-edit"
+	icon = "fas fa-edit"
 	desc = "Contribute to the Jenkins X website"
 [[params.links.user]]
 	name = "User Slack Channel"


### PR DESCRIPTION
# Description
The new icons added aren't showing on routes other than "/"

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

