### PR TITLE
fix: broken links in docs

### DIFF
--- a/content/en/v3/develop/apps/_index.md
+++ b/content/en/v3/develop/apps/_index.md
@@ -110,7 +110,7 @@ releases:
   
 You can also use a file called `values.yaml.gotmpl` if you wish to use go templating of the values file. For example this lets you reference properties from the `jx-requirements.yml` file via expressions like `{{ .Values.jxRequirements.ingress.domain }}`.
 
-To see an example of this in action check out the [charts/jenkins-x/tekton/values.yaml.gotmpl](https://github.com/jenkins-x/jxr-versions/blob/master/charts/jenkins-x/tekton/values.yaml.gotmpl) file in the [version stream](https://jenkins-x.io/about/concepts/version-stream/).
+To see an example of this in action check out the [charts/jenkins-x/tekton/values.yaml.gotmpl](https://github.com/jenkins-x/jx3-versions/blob/master/charts/cdf/tekton-pipeline/values.yaml.gotmpl) file in the [version stream](https://jenkins-x.io/about/concepts/version-stream/).
 
 Note that many apps are already configured to make use of the `jx-requirements.yml` settings via the [version stream](https://jenkins-x.io/about/concepts/version-stream/) - but you are free to add your own custom configuration. 
    

--- a/content/en/v3/develop/create-project/_index.md
+++ b/content/en/v3/develop/create-project/_index.md
@@ -33,7 +33,7 @@ jx project import
 
 If you are using nested gitlab repositories (`org/group/repository`), add `--nested-repo` flag to `jx project import`.
 
-**NOTE** that we recommend [trying out a quickstart first](/v3/develop/create-project/#create-a-new-project-from-a-quickstart) before importing a project so that:
+**NOTE** that we recommend [trying out a quickstart first](#create-a-new-project-from-a-quickstart) before importing a project so that:
 
 - you can verify your cluster is setup correctly so that you can create new charts + images, promote them to staging and create Preview Environments on Pull Requests etc.
 - as you start to import projects which may have their own custom `Dockerfile` or custom charts you can compare your custom chart versus the charts included in the Jenkins X catalog to see how it works. e.g.

--- a/content/en/v3/develop/create-project/_index.md
+++ b/content/en/v3/develop/create-project/_index.md
@@ -33,7 +33,7 @@ jx project import
 
 If you are using nested gitlab repositories (`org/group/repository`), add `--nested-repo` flag to `jx project import`.
 
-**NOTE** that we recommend [trying out a quickstart first](h/v3/develop/create-project/#create-a-new-project-from-a-quickstart) before importing a project so that:
+**NOTE** that we recommend [trying out a quickstart first](/v3/develop/create-project/#create-a-new-project-from-a-quickstart) before importing a project so that:
 
 - you can verify your cluster is setup correctly so that you can create new charts + images, promote them to staging and create Preview Environments on Pull Requests etc.
 - as you start to import projects which may have their own custom `Dockerfile` or custom charts you can compare your custom chart versus the charts included in the Jenkins X catalog to see how it works. e.g.

--- a/content/en/v3/develop/pipelines/_index.md
+++ b/content/en/v3/develop/pipelines/_index.md
@@ -11,6 +11,6 @@ aliases:
 
 As part of the [Tekton Catalog enhancement proposal](https://github.com/jenkins-x/enhancements/issues/37) we've improved support for Tekton in Jenkins X so that you can
 
-  * easily [edit any pipeline in any git repository](/v3/develop/pipelines/#editing-pipelines) by just modifying the [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task), [Pipeline](https://tekton.dev/docs/pipelines/pipelines/#configuring-a-pipeline) or [PipelineRun](https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-pipelinerun) files in your `.ligthhouse/jenkins-x` folder
-  * [add new pipelines to any git repository](#add-new-taskspipelines-by-hand) to reuse any [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task) files you find from places like the [tekton catalog](https://github.com/tektoncd/catalog) in your repositories
+  * easily [edit any pipeline in any git repository](/v3/develop/pipelines/editing) by just modifying the [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task), [Pipeline](https://tekton.dev/docs/pipelines/pipelines/#configuring-a-pipeline) or [PipelineRun](https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-pipelinerun) files in your `.ligthhouse/jenkins-x` folder
+  * [add new pipelines to any git repository](/v3/develop/pipelines/demo/) to reuse any [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task) files you find from places like the [tekton catalog](https://github.com/tektoncd/catalog) in your repositories
 

--- a/content/en/v3/develop/pipelines/_index.md
+++ b/content/en/v3/develop/pipelines/_index.md
@@ -11,6 +11,6 @@ aliases:
 
 As part of the [Tekton Catalog enhancement proposal](https://github.com/jenkins-x/enhancements/issues/37) we've improved support for Tekton in Jenkins X so that you can
 
-  * easily [edit any pipeline in any git repository](/v3/develop/pipelines/editing) by just modifying the [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task), [Pipeline](https://tekton.dev/docs/pipelines/pipelines/#configuring-a-pipeline) or [PipelineRun](https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-pipelinerun) files in your `.ligthhouse/jenkins-x` folder
-  * [add new pipelines to any git repository](/v3/develop/pipelines/demo/) to reuse any [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task) files you find from places like the [tekton catalog](https://github.com/tektoncd/catalog) in your repositories
+  * easily [edit any pipeline in any git repository](editing) by just modifying the [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task), [Pipeline](https://tekton.dev/docs/pipelines/pipelines/#configuring-a-pipeline) or [PipelineRun](https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-pipelinerun) files in your `.ligthhouse/jenkins-x` folder
+  * [add new pipelines to any git repository](editing/#add-new-taskspipelines-by-hand) to reuse any [Task](https://tekton.dev/docs/pipelines/tasks/#configuring-a-task) files you find from places like the [tekton catalog](https://github.com/tektoncd/catalog) in your repositories
 


### PR DESCRIPTION
# Description
Fixing broken links in docs

Fixes [#8043](https://github.com/jenkins-x/jx/issues/8043)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

