### PR TITLE
fix: remove link to deleted tweet and add user and id to tweet shortcode

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -46,7 +46,6 @@ spec:
               name: build-website
               script: |
                 #!/bin/sh
-                ls -al
                 hugo -d tmp-website --enableGitInfo --baseURL https://${REPO_NAME}-jx-${REPO_OWNER}-${REPO_NAME}-pr-${PULL_NUMBER}.${DOMAIN}/
             - image: 18fgsa/html-proofer:latest
               name: htmlproofer

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -369,10 +369,10 @@ linkTitle = "Jenkins X - Cloud Native CI/CD Built On Kubernetes"
       </div>
       <div class="row">
         <div class="col-xs-12 col-md-6">
-          {{< tweet 1154827663758036992 >}}
+          {{< tweet user="ROOT_OR_DEATH" id="1154827663758036992" >}}
         </div>
         <div class="col-xs-12 col-md-6">
-          {{< tweet 1242046208044142594 >}}
+          {{< tweet user="BjoernKraus" id="1242046208044142594" >}}
         </div>
         <div class="w-100">
           <p class="h-75 d-inline-block"><br /></p>

--- a/content/en/blog/news/2021-jx3-builtin-observability.md
+++ b/content/en/blog/news/2021-jx3-builtin-observability.md
@@ -12,8 +12,6 @@ author: Vincent Behar
 
 As a Continuous Delivery platform, Jenkins X has a central part in your infrastructure. If it becomes unstable or unusable, it will impact the whole software delivery of your organization.
 
-{{< tweet 1341177825525547012 >}}
-
 This is why observability is a critical topic for Jenkins X, and work has started to get observability built-in for Jenkins X v3:
 - **Platform Observability**: visualize logs and metrics for everything running in the Kubernetes cluster: Jenkins X's own components - Tekton, Lighthouse, cert-manager, ... - but also your own applications, that will be deployed either in preview environments or in the staging/prod environments.
 - **Continuous Delivery Indicators**: visualize pull requests, pipelines, releases, and deployments metrics, collected from cluster events and git events.


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

# Description

A tweet we use in a blog was removed, so twitter returned an error. 
Let's not use `ignoreErrors = ["error-remote-getjson"]` to ignore the these kind of errors (always better to remove things that dont work instead of ignoring them).
Also tweet shortcode now requires an user and id, fixing that also

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

