### PR TITLE
docs: wrapping commands in a bash block

### DIFF
--- a/content/en/v3/admin/platforms/eks/_index.md
+++ b/content/en/v3/admin/platforms/eks/_index.md
@@ -59,30 +59,34 @@ Note: remember to create the Git repositories below in your Git Organization rat
   - jx_bot_username: The username of the git bot user
 
 - commit and push any changes to your Infrastructure git repository:
-
+```bash
       git commit -a -m "fix: configure cluster repository and project"
       git push
+```
 
 - Define an environment variable to pass the bot token into Terraform:
-
+```bash
       export TF_VAR_jx_bot_token=my-bot-token
+```
 
 - Now, initialise, plan and apply Terraform:
-
+```bash
       terraform init
       terraform plan
       terraform apply
+```
 
 - Tail the Jenkins X installation logs
-
+```bash
   $(terraform output follow_install_logs)
+```
 
 - Once finished you can now move into the Jenkins X Developer namespace
-
+```bash
   jx ns jx
-
+```
 - and create or import your applications
 
-- <a href="/v3/develop/create-project/" class="btn bg-primary text-light">Create or import projects</a>
+- <a href="https://jenkins-x.io/v3/develop/create-project/" class="btn bg-primary text-light">Create or import projects</a>
 
 For more details on how to install Jenkins X on AWS EKS see [Github repository for Jenkins X Terraform module for EKS](https://github.com/jx3-gitops-repositories/jx3-terraform-eks#prerequisites)


### PR DESCRIPTION
For the documentation on how to set up [Jenkins x on Amazon](https://jenkins-x.io/v3/admin/platforms/eks/)
Wrapping every commands block into bash block 
altering the link to create or import projects to refer to the website

# Description
I think this was looking fine on the _index.md in GitHub but the website now looks like this :

![Screenshot from 2022-03-21 16-10-10](https://user-images.githubusercontent.com/59124937/159279768-21e3fc67-ff66-4070-ba1b-663b811c3a75.png)

Fixes # (issue)

# Checklist:
- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

