### PR TITLE
fix: Removing faulty information regarding kaniko flags

### DIFF
--- a/content/en/v3/develop/faq/config/general.md
+++ b/content/en/v3/develop/faq/config/general.md
@@ -47,11 +47,6 @@ spec:
     kanikoFlags: "--snapshotMode=redo"     
 ```
 
-To override it for a specific repository you can use the `.jx/settings.yaml` to configure the same thing.
-
-See the [file reference](/v3/develop/reference/files/)
-
-
 ## If I add a file to `config-root` it gets deleted, why?
 
 The `config-root` directory is regenerated on every boot job - basically every time you promote an application or merge a change into the main branch of your git dev cluster git repository.  For background see the [dev git repository layout docs](https://github.com/jenkins-x/jx-gitops/blob/master/docs/git_layout.md))


### PR DESCRIPTION


# Description

As far as my testing and source code investigations go kaniko flags set in `.jx/settings.yaml` are not used.

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

