### PR TITLE
fix: remove v tag from docsy package name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/jenkins-x/jx-docs
 go 1.17
 
 require (
-	github.com/google/docsy v0.2.0-pre // indirect
-	github.com/google/docsy/dependencies v0.2.0-pre // indirect
+	github.com/google/docsy v0.1.1-0.20220329190916-9733a5f72258 // indirect
+	github.com/google/docsy/dependencies v0.2.0-pre.0.20220329190916-9733a5f72258 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,14 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 h1:+vc8wn8oOlLhjUOTvP6ljXuIi03HZWb9jWc4ZhVrO9g=
+github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
+github.com/google/docsy v0.1.1-0.20220329190916-9733a5f72258 h1:Zu74mUwQ9Ou+/U0UcrXIDuvXFGy4OjYUGnRUKiyEyP8=
+github.com/google/docsy v0.1.1-0.20220329190916-9733a5f72258/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
 github.com/google/docsy v0.2.0-pre h1:vQc8vUD6ArSKCZM2BA1tckwhHSA5Vi3GwqtdywQiAaU=
 github.com/google/docsy v0.2.0-pre/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
 github.com/google/docsy/dependencies v0.2.0-pre h1:rr4XfnpvqIEuG71jpo6p7e1/kxvkHQJNh7ewqWpzJzg=
 github.com/google/docsy/dependencies v0.2.0-pre/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 h1:EKYx2OlWxo2HBhZ+dWzZbufBfh+qMKmz2K1lf1GJmto=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220329190916-9733a5f72258 h1:CwV2w2MfY7qGqOY59VjvfH3GFhVJqtP2oUpxDvpLq54=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220329190916-9733a5f72258/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
 github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
# Description

Suddenly builds started failing due to docsy as a go module.

This PR fixes breaking release builds due to docsy package naming scheme changes.

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

