### PR TITLE
K3s - added new page for installing Vault inside Kubernetes

### DIFF
--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -13,13 +13,13 @@ aliases:
 
 This guide will walk you though how to setup Jenkins X on your own computer using [k3s](https://k3s.io/) and vault running in docker.
 
-If you would rather run vault inside of k3s, which makes the install procedure somewhat simpler, see this [guide](/v3/admin/platform/k3s/internal_vault)
+If you would rather run vault inside of k3s, which makes the install procedure somewhat simpler, see this [guide](https://jenkins-x.io/v3/admin/platform/k3s/internal_vault)
 
-Please see the [Troubleshooting guide](/v3/admin/platform/k3s/troubleshooting) if you run into problems.
+Please see the [Troubleshooting guide](https://jenkins-x.io/v3/admin/platform/k3s/troubleshooting) if you run into problems.
 
 #### K3s
 
-Make sure you have [created a cluster using k3](/v3/admin/platforms/k3s/cluster).
+Make sure you have [created a cluster using k3](https://jenkins-x.io/v3/admin/platforms/k3s/cluster).
 
 #### Vault
 To install vault on docker, you first need to install [docker](https://docs.docker.com/engine/install/) and [manage it as a non root user](https://docs.docker.com/engine/install/linux-postinstall/)
@@ -142,7 +142,7 @@ This job will create the secrets in vault which will be used by external secrets
 ### Set up ingress and webhook
 
 Your cluster should now be ready and running.
-To allow git to send webhooks, you can [set up a tunnel using ngrok](ngrok) 
+To allow git to send webhooks, you can [set up a tunnel using ngrok](https://jenkins-x.io/v3/admin/platform/k3s/ngrok)
 ### Next steps
 
 - <a href="/v3/develop/create-project/" class="btn bg-primary text-light">Create or import projects</a>

--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -36,7 +36,6 @@ sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-config
 # export kubeconfig
 export KUBECONFIG=~/.kube/config:~/.kube/k3s-config
 ```
-
 #### macOS
 ```bash
 # install multipass

--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -128,7 +128,7 @@ jx admin operator --username $GIT_USERNAME --token $GIT_TOKEN --url <url of the 
 > The errors will be of the form `error: failed to populate secrets: failed to create a secret manager for ExternalSecret`.
 > Once the secret-infra namespace has been created, we can configure vault.
 > If you get an error connecting to the cluster, try running `kubectl config view --raw >~/.kube/config` as well as checking the permissions/owner of `~/.kube/config`
-### Vault configuration (only needed for external vault installation)
+### Vault configuration 
 
 Install [jq](https://stedolan.github.io/jq/download/) before running these commands.
 

--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -13,7 +13,7 @@ aliases:
 
 This guide will walk you though how to setup Jenkins X on your own computer using [k3s](https://k3s.io/) and vault running in docker.
 
-If you would rather run vault inside of k3s, which makes the install procedure somewhat simpler, see this [guide](/v3/admin/platform/k3s/internal-vault)
+If you would rather run vault inside of k3s, which makes the install procedure somewhat simpler, see this [guide](/v3/admin/platform/k3s/internal_vault)
 
 Please see the [Troubleshooting guide](/v3/admin/platform/k3s/troubleshooting) if you run into problems.
 
@@ -21,7 +21,7 @@ Please see the [Troubleshooting guide](/v3/admin/platform/k3s/troubleshooting) i
 
 Make sure you have [created a cluster using k3](/v3/admin/platforms/k3s/cluster).
 
-#### Vault 
+#### Vault
 To install vault on docker, you first need to install [docker](https://docs.docker.com/engine/install/) and [manage it as a non root user](https://docs.docker.com/engine/install/linux-postinstall/)
 
 Install vault cli.
@@ -141,52 +141,8 @@ This job will create the secrets in vault which will be used by external secrets
 
 ### Set up ingress and webhook
 
-- Get the external IP of the traefik service (loadbalancer)
-
-```bash
-kubectl get svc -A | grep LoadBalancer
-kube-system   traefik          LoadBalancer   <cluster-ip>    <external-ip>    80:31123/TCP,443:31783/TCP   40m
-```
-
-- Edit the jx-requirements.yaml file by editing the ingress domain:
-
-```bash
-# There may be some changes committed by the jx boot job
-git pull
-jx gitops requirements edit --domain <external-ip>.nip.io
-```
-
-- Next, download and install [ngrok](https://ngrok.com/). Run this in a new terminal window/tab:
-
-```bash
-ngrok http 8080
-```
-
-- Once this tunnel is open, paste the ngrok url (without http and https) in the hook field in the helmfiles/jx/jxboot-helmfile-resources-values.yaml file in the cluster git repository.
-- commit and push the changes.
-
-```bash
-git add .
-git commit -m "chore: new ngrok ip"
-git push origin main
-```
-
-- In another terminal run the following command to enable webhooks via ngrok
-
-```bash
-jx ns jx
-kubectl port-forward svc/hook 8080:80
-```
-
-- Once the bootjob has succeeded, you should see:
-
-```bash
-HTTP Requests
--------------
-
-POST /hook                     200 OK
-```
-
+Your cluster should now be ready and running.
+To allow git to send webhooks, you can [set up a tunnel using ngrok](ngrok) 
 ### Next steps
 
 - <a href="/v3/develop/create-project/" class="btn bg-primary text-light">Create or import projects</a>

--- a/content/en/v3/admin/platforms/k3s/cluster.md
+++ b/content/en/v3/admin/platforms/k3s/cluster.md
@@ -1,0 +1,62 @@
+---
+title: K3s cluster
+linktitle: Cluster installation
+type: docs
+description: Install k3s cluster on your own computer
+date: 2022-04-04
+
+weight: 50
+aliases:
+  - /v3/admin/platform/k3s/cluster
+---
+
+This guide explains how to install k3s for running kubernetes on your own computer.
+
+#### Linux
+```bash
+# install k3 with kubernetes version 1.21 (We don't support Kubernetes 1.22+ yet)
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.21 sh -s - --write-kubeconfig-mode 644
+# copy kubeconfig
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-config
+# export kubeconfig
+export KUBECONFIG=~/.kube/config:~/.kube/k3s-config
+```
+#### macOS
+For macOS, we need to first install [multipass](https://multipass.run/), create a VM with multipass and then install k3s on this VM.
+```bash
+# install multipass
+brew install --cask multipass
+# Create a vm with 2G memory and 5G disk
+multipass launch --name k3sVM --mem 4G --disk 10G
+# install k3 with kubernetes version 1.21 (We don't support Kubernetes 1.22+ yet)
+multipass shell k3sVM
+# once you are into the k3sVM shell
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.21 sh -s - --write-kubeconfig-mode 644
+# after this install you should be able to run kubectl get nodes
+kubectl get nodes
+# exit the k3sVM shell
+exit
+```
+
+Next, after exiting the k3sVM shell, find the IP address of the running node, and export the kubeconfig file
+```bash
+multipass info k3sVM
+# Export the IP address
+K3S_IP=$(multipass info k3sVM | grep IPv4 | awk '{print $2}')
+# export `kubeconfig` file
+multipass exec k3sVM sudo cat /etc/rancher/k3s/k3s.yaml > k3s.yaml
+# replace the ip adress with the external
+sed -i '' "s/127.0.0.1/${K3S_IP}/" k3s.yaml
+# set KUBECONFIG
+export KUBECONFIG={$PWD}/k3s.yaml
+```
+#### Verify k3s available
+To verify that k3s has been installed successfully, and configured run:
+
+```bash
+kubectl get nodes
+```
+
+Check [k3s install guide](https://rancher.com/docs/k3s/latest/en/installation/) for more installation options.
+
+

--- a/content/en/v3/admin/platforms/k3s/cluster.md
+++ b/content/en/v3/admin/platforms/k3s/cluster.md
@@ -26,8 +26,9 @@ For macOS, we need to first install [multipass](https://multipass.run/), create 
 ```bash
 # install multipass
 brew install --cask multipass
-# Create a vm with 2G memory and 5G disk
-multipass launch --name k3sVM --mem 4G --disk 10G
+# Create a vm with 4G memory and 30G disk and 4 CPU
+# this worked on my machine but you may need to adjust according to your system and your needs
+multipass launch --name k3sVM --mem 4G --disk 30G -c 4
 # install k3 with kubernetes version 1.21 (We don't support Kubernetes 1.22+ yet)
 multipass shell k3sVM
 # once you are into the k3sVM shell
@@ -47,8 +48,11 @@ K3S_IP=$(multipass info k3sVM | grep IPv4 | awk '{print $2}')
 multipass exec k3sVM sudo cat /etc/rancher/k3s/k3s.yaml > k3s.yaml
 # replace the ip adress with the external
 sed -i '' "s/127.0.0.1/${K3S_IP}/" k3s.yaml
+# set permissions on the kubeconfig file
+chmod 0644 k3s.yaml
 # set KUBECONFIG
-export KUBECONFIG={$PWD}/k3s.yaml
+export KUBECONFIG=${PWD}/k3s.yaml
+cat "$KUBECONFIG"
 ```
 #### Verify k3s available
 To verify that k3s has been installed successfully, and configured run:
@@ -58,5 +62,3 @@ kubectl get nodes
 ```
 
 Check [k3s install guide](https://rancher.com/docs/k3s/latest/en/installation/) for more installation options.
-
-

--- a/content/en/v3/admin/platforms/k3s/cluster.md
+++ b/content/en/v3/admin/platforms/k3s/cluster.md
@@ -39,7 +39,7 @@ kubectl get nodes
 exit
 ```
 
-Next, after exiting the k3sVM shell, find the IP address of the running node, and export the kubeconfig file
+Next, after exiting the k3sVM shell, we need to export the kubeconfig file,  update it with the IP address of the running node, and finally export the kubeconfig file.
 ```bash
 multipass info k3sVM
 # Export the IP address
@@ -49,7 +49,7 @@ multipass exec k3sVM sudo cat /etc/rancher/k3s/k3s.yaml > k3s.yaml
 # replace the ip adress with the external
 sed -i '' "s/127.0.0.1/${K3S_IP}/" k3s.yaml
 # set permissions on the kubeconfig file
-chmod 0644 k3s.yaml
+chmod go-r k3s.yaml
 # set KUBECONFIG
 export KUBECONFIG=${PWD}/k3s.yaml
 cat "$KUBECONFIG"

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -62,7 +62,7 @@ It should install.
 ### Set up ingress and webhook
 
 Your cluster should now be ready and running.
-To allow git to send webhooks, you can [set up a tunnel using ngrok](ngrok)
+To allow git to send webhooks, you can [set up a tunnel using ngrok](https://jenkins-x.io/v3/admin/platform/k3s/ngrok)
 
 ### Next steps
 

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -12,11 +12,11 @@ aliases:
 
 This guide will walk you though how to setup Jenkins X on your own computer using [k3s](https://k3s.io/) and vault running inside the k3s cluster.
 
-Please see the [troubleshooting guide](/v3/admin/platform/k3s/troubleshooting) if you run into problems.
+Please see the [troubleshooting guide](https://jenkins-x.io/v3/admin/platform/k3s/troubleshooting) if you run into problems.
 
 #### K3s
 
-Make sure you have [created a cluster using k3](/v3/admin/platforms/k3s/cluster).
+Make sure you have [created a cluster using k3](https://jenkins-x.io/v3/admin/platforms/k3s/cluster).
 
 ### Github
 

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -29,9 +29,20 @@ Make sure you have [created a cluster using k3](https://jenkins-x.io/v3/admin/pl
 
 - Generate a cluster git repository from the [jx3-k3s-vault](https://github.com/jx3-gitops-repositories/jx3-k3s-vault) template, by clicking [here](https://github.com/jx3-gitops-repositories/jx3-k3s-vault/generate)
 
+### Install vault in cluster
+Open a terminal in the root folder of the checked out repository and enter the following commands to install vault inside the k3s cluster.
+You may have to install helmfile.
+
+```bash
+cd jx-vault
+helmfile sync
+```
+Vault should now be installed in the jx-vault namespace, verify with `kubectl get pods -n jx-vault` 
+
+
 ### Install Jenkins X
 
-- Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and cluster run from the root folder of the cluster repo:
+- Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and run from the root folder of the cluster repo:
 
 ```bash
 jx admin operator

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -47,17 +47,17 @@ git commit -m "fix: set vault url"
 git push origin main
 ```
 
-- Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and run:
+- Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and cluster run from the root folder of the cluster repo:
 
 ```bash
-jx admin operator --username $GIT_USERNAME --token $GIT_TOKEN --url <url of the cluster git repo>
+jx admin operator 
 ```
-It should install.
+Jenkins X should now install.
 
 ### Verify installation
 
 - To verify the job succeeded, run `jx admin log`
-- To verfiy the secrets were created, run `kubectl get es -A` and `jx secret verify`
+- To verify the secrets were created, run `kubectl get es -A` and `jx secret verify`
 
 ### Set up ingress and webhook
 

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -5,7 +5,7 @@ type: docs
 description: Setup Jenkins X on a K3s cluster on your computer, with vault installed inside Kubernetes
 date: 2022-04-04
 publishdate: 2022-04-04
-weight: 50
+weight: 40
 aliases:
   - /v3/admin/platform/k3s/k3s-vault
 ---
@@ -31,6 +31,7 @@ Make sure you have [created a cluster using k3](/v3/admin/platforms/k3s/cluster)
 
 ### Install vault in cluster
 Open a terminal in the root folder of the checked out repository and enter the following commands to install vault inside the k3s cluster.
+You may have to install helmfile.
 
 ```bash
 cd jx-vault
@@ -60,51 +61,8 @@ It should install.
 
 ### Set up ingress and webhook
 
-- Get the external IP of the traefik service (loadbalancer)
-
-```bash
-kubectl get svc -A | grep LoadBalancer
-kube-system   traefik          LoadBalancer   <cluster-ip>    <external-ip>    80:31123/TCP,443:31783/TCP   40m
-```
-
-- Edit the jx-requirements.yaml file by editing the ingress domain:
-
-```bash
-# There may be some changes committed by the jx boot job
-git pull
-jx gitops requirements edit --domain <external-ip>.nip.io
-```
-
-- Next, download and install [ngrok](https://ngrok.com/). Run this in a new terminal window/tab:
-
-```bash
-ngrok http 8080
-```
-
-- Once this tunnel is open, paste the ngrok url (without http and https) in the hook field in the helmfiles/jx/jxboot-helmfile-resources-values.yaml file in the cluster git repository.
-- commit and push the changes.
-
-```bash
-git add .
-git commit -m "chore: new ngrok ip"
-git push origin main
-```
-
-- In another terminal run the following command to enable webhooks via ngrok
-
-```bash
-jx ns jx
-kubectl port-forward svc/hook 8080:80
-```
-
-- Once the bootjob has succeeded, you should see:
-
-```bash
-HTTP Requests
--------------
-
-POST /hook                     200 OK
-```
+Your cluster should now be ready and running.
+To allow git to send webhooks, you can [set up a tunnel using ngrok](ngrok)
 
 ### Next steps
 

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -1,96 +1,39 @@
 ---
-title: K3s using Vault inside kubernetes
-linktitle: Internal Vault
+title: K3s with vault inside kubernetes
+linktitle: Vault inside k3s
 type: docs
-description: Setup Jenkins X on a K3s cluster running locally, with Vault installed inside Kubernetes
-date: 2022-04-03
-publishdate: 2022-04-03
+description: Setup Jenkins X on a K3s cluster on your computer, with vault installed inside Kubernetes
+date: 2022-04-04
+publishdate: 2022-04-04
 weight: 50
 aliases:
-  - /v3/admin/platform/k3s/internal-vault
+  - /v3/admin/platform/k3s/k3s-vault
 ---
 
----
-This is an alternative procedure to install k3s with Vault running inside the cluster.  
+This guide will walk you though how to setup Jenkins X on your own computer using [k3s](https://k3s.io/) and vault running inside the k3s cluster.
 
-**NOTE**
-
-Ensure you are logged into GitHub else you will get a 404 error when clicking the links below
-
-This guide will walk you though how to setup Jenkins X on your laptop using [k3s](https://k3s.io/)
-
-### Prerequisites
+Please see the [troubleshooting guide](/v3/admin/platform/k3s/troubleshooting) if you run into problems.
 
 #### K3s
 
-Make sure you have created a cluster using k3s.
+Make sure you have [created a cluster using k3](/v3/admin/platforms/k3s/cluster).
 
-If you dont have an existing k3s cluster, you can install one by running:
-
-#### Linux
-```bash
-# install k3 with kubernetes version 1.21 (We don't support Kubernetes 1.22+ yet)
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.21 sh -s - --write-kubeconfig-mode 644
-# copy kubeconfig
-sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-config
-# export kubeconfig
-export KUBECONFIG=~/.kube/config:~/.kube/k3s-config
-```
-#### macOS
-```bash
-# install multipass
-brew install --cask multipass
-# Create a vm with 2G memory and 5G disk
-multipass launch --name k3sVM --mem 4G --disk 10G
-# install k3 with kubernetes version 1.21 (We don't support Kubernetes 1.22+ yet)
-multipass shell k3sVM
-# once you are into the k3sVM shell
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.21 sh -s - --write-kubeconfig-mode 644
-# after this install you should be able to run kubectl get nodes
-kubectl get nodes
-# exit the k3sVM shell
-exit
-```
-
-Next, after exiting the k3sVM shell, find the IP address of the running node, and export the kubeconfig file
-```bash
-multipass info k3sVM
-# Export the IP address
-K3S_IP=$(multipass info k3sVM | grep IPv4 | awk '{print $2}')
-# export `kubeconfig` file
-multipass exec k3sVM sudo cat /etc/rancher/k3s/k3s.yaml > k3s.yaml
-# replace the ip adress with the external
-sed -i '' "s/127.0.0.1/${K3S_IP}/" k3s.yaml
-# set KUBECONFIG
-export KUBECONFIG={$PWD}/k3s.yaml
-```
-#### Verify k3s available
-To verify that k3s has been installed successfully, and configured run:
+### Vault installed in cluster
+Once kubernetes is running, enter the following commands to have vault started inside the k3s clusters
 
 ```bash
-kubectl get nodes
-```
-
-This value of the node will be used later during installation and configuring of Jenkins X.
-
-Check [k3s install guide](https://rancher.com/docs/k3s/latest/en/installation/) for more installation options.
-
-
-
-##### Vault installed in  cluster
-Once kubernetes is running, enter the following commands to have Vault started inside the k3s clusters
-```
-cd infra
+cd jx-vault
 helmfile sync
-
 ```
 
-#### Github
+### Github
 
 - Create a git bot user (different from your own personal user) e.g. https://github.com/join and generate a a personal access token, this will be used by Jenkins X to interact with git repositories. e.g. https://github.com/settings/tokens/new?scopes=repo,read:user,read:org,user:email,write:repo_hook,delete_repo,admin:repo_hook
 - This bot user needs to have write permission to write to any git repository used by Jenkins X. This can be done by adding the bot user to the git organisation level or individual repositories as a collaborator Add the new bot user to your Git Organisation, for now give it Owner permissions, we will reduce this to member permissions soon.
 
 ### Jenkins X v3 installation
+
+- Make sure you have installed [jx 3.x binary](https://jenkins-x.io/v3/admin/setup/jx3/) and put it on your `$PATH` as the `jx admin operator` will be used
 
 - Generate a cluster git repository from the [jx3-k3s-vault](https://github.com/jx3-gitops-repositories/jx3-k3s-vault) template, by clicking [here](https://github.com/jx3-gitops-repositories/jx3-k3s-vault/generate)
  Commit and push your changes:
@@ -101,8 +44,6 @@ git commit -m "fix: set vault url"
 git push origin main
 ```
 - Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and run:
-
-#### Using internal vault:
 
 ```bash
 jx admin operator --username $GIT_USERNAME --token $GIT_TOKEN --url <url of the cluster git repo>

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -29,14 +29,6 @@ Make sure you have [created a cluster using k3](https://jenkins-x.io/v3/admin/pl
 
 - Generate a cluster git repository from the [jx3-k3s-vault](https://github.com/jx3-gitops-repositories/jx3-k3s-vault) template, by clicking [here](https://github.com/jx3-gitops-repositories/jx3-k3s-vault/generate)
 
-### Install vault in cluster
-Open a terminal in the root folder of the checked out repository and enter the following commands to install vault inside the k3s cluster.
-You may have to install helmfile.
-
-```bash
-cd jx-vault
-helmfile sync
-```
 ### Install Jenkins X
 
 Commit and push your changes:
@@ -50,7 +42,7 @@ git push origin main
 - Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and cluster run from the root folder of the cluster repo:
 
 ```bash
-jx admin operator 
+jx admin operator
 ```
 Jenkins X should now install.
 

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -18,31 +18,34 @@ Please see the [troubleshooting guide](/v3/admin/platform/k3s/troubleshooting) i
 
 Make sure you have [created a cluster using k3](/v3/admin/platforms/k3s/cluster).
 
-### Vault installed in cluster
-Once kubernetes is running, enter the following commands to have vault started inside the k3s clusters
-
-```bash
-cd jx-vault
-helmfile sync
-```
-
 ### Github
 
 - Create a git bot user (different from your own personal user) e.g. https://github.com/join and generate a a personal access token, this will be used by Jenkins X to interact with git repositories. e.g. https://github.com/settings/tokens/new?scopes=repo,read:user,read:org,user:email,write:repo_hook,delete_repo,admin:repo_hook
 - This bot user needs to have write permission to write to any git repository used by Jenkins X. This can be done by adding the bot user to the git organisation level or individual repositories as a collaborator Add the new bot user to your Git Organisation, for now give it Owner permissions, we will reduce this to member permissions soon.
 
-### Jenkins X v3 installation
+### Checkout Jenkins X github repository
 
 - Make sure you have installed [jx 3.x binary](https://jenkins-x.io/v3/admin/setup/jx3/) and put it on your `$PATH` as the `jx admin operator` will be used
 
 - Generate a cluster git repository from the [jx3-k3s-vault](https://github.com/jx3-gitops-repositories/jx3-k3s-vault) template, by clicking [here](https://github.com/jx3-gitops-repositories/jx3-k3s-vault/generate)
- Commit and push your changes:
+
+### Install vault in cluster
+Open a terminal in the root folder of the checked out repository and enter the following commands to install vault inside the k3s cluster.
+
+```bash
+cd jx-vault
+helmfile sync
+```
+### Install Jenkins X
+
+Commit and push your changes:
 
 ```bash
 git add .
 git commit -m "fix: set vault url"
 git push origin main
 ```
+
 - Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and run:
 
 ```bash

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -1,6 +1,6 @@
 ---
 title: K3s using Vault inside kubernetes
-linktitle: K3s-internal-vault
+linktitle: Internal Vault
 type: docs
 description: Setup Jenkins X on a K3s cluster running locally, with Vault installed inside Kubernetes
 date: 2022-04-03

--- a/content/en/v3/admin/platforms/k3s/internal_vault.md
+++ b/content/en/v3/admin/platforms/k3s/internal_vault.md
@@ -31,14 +31,6 @@ Make sure you have [created a cluster using k3](https://jenkins-x.io/v3/admin/pl
 
 ### Install Jenkins X
 
-Commit and push your changes:
-
-```bash
-git add .
-git commit -m "fix: set vault url"
-git push origin main
-```
-
 - Set the GIT_USERNAME (bot username) and GIT_TOKEN (bot personal access token) env variable and cluster run from the root folder of the cluster repo:
 
 ```bash

--- a/content/en/v3/admin/platforms/k3s/ngrok.md
+++ b/content/en/v3/admin/platforms/k3s/ngrok.md
@@ -10,7 +10,7 @@ aliases:
   - /v3/admin/platform/k3s/ngrok
 ---
 
-This guide explains how to add ngrok to a running k3s cluster.
+This guide explains how we can use [ngrok](https://ngrok.com/) to allow a kubernetes cluster running on your own computer to accept connections from the internet. 
 
 - Get the external IP of the traefik service (loadbalancer)
 

--- a/content/en/v3/admin/platforms/k3s/ngrok.md
+++ b/content/en/v3/admin/platforms/k3s/ngrok.md
@@ -15,8 +15,9 @@ This guide explains how to add ngrok to a running k3s cluster.
 - Get the external IP of the traefik service (loadbalancer)
 
 ```bash
-kubectl get svc -A | grep LoadBalancer
-kube-system   traefik          LoadBalancer   <cluster-ip>    <external-ip>    80:31123/TCP,443:31783/TCP   40m
+LOADBALANCER=$(kubectl get svc traefik -n kube-system --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}")
+echo $LOADBALANCER
+
 ```
 
 - Edit the jx-requirements.yaml file by editing the ingress domain:
@@ -24,7 +25,7 @@ kube-system   traefik          LoadBalancer   <cluster-ip>    <external-ip>    8
 ```bash
 # There may be some changes committed by the jx boot job
 git pull
-jx gitops requirements edit --domain <external-ip>.nip.io
+jx gitops requirements edit --domain "${LOADBALANCER}.nip.io"
 ```
 
 - Next, download and install [ngrok](https://ngrok.com/). Run this in a new terminal window/tab:

--- a/content/en/v3/admin/platforms/k3s/ngrok.md
+++ b/content/en/v3/admin/platforms/k3s/ngrok.md
@@ -1,0 +1,59 @@
+---
+title: ngrok for K3s cluster
+linktitle: ngrok for k3s cluster
+type: docs
+description: How to make k3s cluster accept connections from the internet
+date: 2022-04-13
+
+weight: 350
+aliases:
+  - /v3/admin/platform/k3s/ngrok
+---
+
+This guide explains how to add ngrok to a running k3s cluster.
+
+- Get the external IP of the traefik service (loadbalancer)
+
+```bash
+kubectl get svc -A | grep LoadBalancer
+kube-system   traefik          LoadBalancer   <cluster-ip>    <external-ip>    80:31123/TCP,443:31783/TCP   40m
+```
+
+- Edit the jx-requirements.yaml file by editing the ingress domain:
+
+```bash
+# There may be some changes committed by the jx boot job
+git pull
+jx gitops requirements edit --domain <external-ip>.nip.io
+```
+
+- Next, download and install [ngrok](https://ngrok.com/). Run this in a new terminal window/tab:
+
+```bash
+ngrok http 8080
+```
+
+- Once this tunnel is open, paste the ngrok url (without http and https) in the hook field in the helmfiles/jx/jxboot-helmfile-resources-values.yaml file in the cluster git repository.
+- commit and push the changes.
+
+```bash
+git add .
+git commit -m "chore: new ngrok ip"
+git push origin main
+```
+
+- In another terminal run the following command to enable webhooks via ngrok
+
+```bash
+jx ns jx
+kubectl port-forward svc/hook 8080:80
+```
+
+- Once the bootjob has succeeded, you should see:
+
+```bash
+HTTP Requests
+-------------
+
+POST /hook                     200 OK
+```

--- a/content/en/v3/admin/platforms/k3s/troubleshooting.md
+++ b/content/en/v3/admin/platforms/k3s/troubleshooting.md
@@ -4,7 +4,7 @@ type: docs
 description: Tips to troubleshoot Jenkins X on k3s
 date: 2022-04-04
 publishdate: 2022-04-04
-weight: 50
+weight: 550
 aliases:
   - /v3/admin/platform/k3s/troubleshooting
 ---
@@ -15,8 +15,14 @@ aliases:
 
 
 ### Vault
-- If you get the error `Error enabling kubernetes auth: Post "https://127.0.0.1:8200/v1/sys/auth/kubernetes": http: server gave HTTP response to HTTPS client`, try the command `vault login myroot`.
-
+- If you get the error
+```bash
+Error enabling kubernetes auth: Post "https://127.0.0.1:8200/v1/sys/auth/kubernetes": http: server gave HTTP response to HTTPS client
+```
+please try the command below.
+ ```bash
+ vault login myroot
+ ```
 ### Kubernetes config
 
 You will probably need to access kubernetes in multiple terminals later, so setting these env variables in the bashrc or zshrc might help you.

--- a/content/en/v3/admin/platforms/k3s/troubleshooting.md
+++ b/content/en/v3/admin/platforms/k3s/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
-title: Troubleshooting guide 
+title: Troubleshooting guide
 type: docs
-description: Tips to troubleshoot Jenkins X on k3s 
+description: Tips to troubleshoot Jenkins X on k3s
 date: 2022-04-04
 publishdate: 2022-04-04
 weight: 50
@@ -27,12 +27,12 @@ nano ~/.bashrc
 export KUBECONFIG=~/.kube/config:~/.kube/k3s-config
 ```
 
-- If you have problmes with kubeconfig, copy the configuration from /etc/rancher/k3s/k3s.yaml to the ~/.kube/config instead (if you don't have any other clusters, that should be fine)
+- If you have problems with kubeconfig, copy the configuration from /etc/rancher/k3s/k3s.yaml to the ~/.kube/config instead (if you don't have any other clusters, that should be fine)
 ```bash
 sudo rm ~/.kube/k3s-config  #to make k3s uses ~/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 ```
-- If still got `permission denied`
+- If you still get `permission denied`
 ```bash
-sudo chmod 777 ~/.kube/config #warning: this maybe vulnerable to multiple users 
+sudo chmod 777 ~/.kube/config #warning: this maybe vulnerable to multiple users
 ```

--- a/content/en/v3/admin/platforms/k3s/troubleshooting.md
+++ b/content/en/v3/admin/platforms/k3s/troubleshooting.md
@@ -1,0 +1,38 @@
+---
+title: Troubleshooting guide 
+type: docs
+description: Tips to troubleshoot Jenkins X on k3s 
+date: 2022-04-04
+publishdate: 2022-04-04
+weight: 50
+aliases:
+  - /v3/admin/platform/k3s/troubleshooting
+---
+
+### Git
+- If you get a 404 error when clicking on the links to create a repository, check that you are actually logged in to GitHub or your git provider.
+
+
+
+### Vault
+- If you get the error `Error enabling kubernetes auth: Post "https://127.0.0.1:8200/v1/sys/auth/kubernetes": http: server gave HTTP response to HTTPS client`, try the command `vault login myroot`.
+
+### Kubernetes config
+
+You will probably need to access kubernetes in multiple terminals later, so setting these env variables in the bashrc or zshrc might help you.
+
+```bash
+nano ~/.bashrc
+#go to the end of the file and paste the export command
+export KUBECONFIG=~/.kube/config:~/.kube/k3s-config
+```
+
+- If you have problmes with kubeconfig, copy the configuration from /etc/rancher/k3s/k3s.yaml to the ~/.kube/config instead (if you don't have any other clusters, that should be fine)
+```bash
+sudo rm ~/.kube/k3s-config  #to make k3s uses ~/.kube/config
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+```
+- If still got `permission denied`
+```bash
+sudo chmod 777 ~/.kube/config #warning: this maybe vulnerable to multiple users 
+```

--- a/content/en/v3/admin/platforms/k3s/troubleshooting.md
+++ b/content/en/v3/admin/platforms/k3s/troubleshooting.md
@@ -12,7 +12,16 @@ aliases:
 ### Git
 - If you get a 404 error when clicking on the links to create a repository, check that you are actually logged in to GitHub or your git provider.
 
+### Delete cluster
+To delete the cluster, get a shell into the cluster and run
+```bash
+ multipass shell k3sVM
+ # you are now inside the cluster
+ # uninstall kubernetes_
+ /usr/local/bin/k3s-uninstall.sh
+```
 
+See the [k3s guide](https://rancher.com/docs/k3s/latest/en/installation/uninstall/) for more information.
 
 ### Vault
 - If you get the error


### PR DESCRIPTION
# Description

Installing Jenkins X on a developer laptop should be easier. Adding a new page with instructions on how to install Vault inside of Kubernetes. This requires this [PR](https://github.com/jx3-gitops-repositories/jx3-k3s-vault/pull/3) to be merged first

Fixes [#8106 (issue)](https://github.com/jenkins-x/jx/issues/8106)

