### PR TITLE
fix: Minikube set kubernetes version

### DIFF
--- a/content/en/v3/admin/platforms/minikube/_index.md
+++ b/content/en/v3/admin/platforms/minikube/_index.md
@@ -39,7 +39,7 @@ minikube delete
 - You need to create a `minikube` cluster via the following command:
 
 ```bash
-minikube start --cpus 4 --memory 8048 --disk-size=100g --addons=ingress --vm=true
+minikube start --cpus 4 --memory 8048 --disk-size=100g --addons=ingress 
 ```
 
 ## Setup

--- a/content/en/v3/admin/platforms/minikube/_index.md
+++ b/content/en/v3/admin/platforms/minikube/_index.md
@@ -39,7 +39,7 @@ minikube delete
 - You need to create a `minikube` cluster via the following command:
 
 ```bash
-minikube start --cpus 4 --memory 8048 --disk-size=100g --addons=ingress 
+minikube start --kubernetes-version=v1.21.11 --cpus 4 --memory 6048 --disk-size=100g --addons=ingress
 ```
 
 ## Setup


### PR DESCRIPTION
# Description
Jenkins X is currently only runnning on no version later than 1.21 of kubernetes, that needs to be set as argument to minikube