### PR TITLE
docs:added k3s wsl2 setup code snippet

### DIFF
--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -81,7 +81,10 @@ Make sure you have vault running in a docker container with kubernetes auth enab
 ```bash
 docker run --name jx-k3s-vault -d --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' --net host vault:latest
 ```
-
+##### For WSL2 Distros use the following command:
+```bash
+docker run --name jx-k3s-vault -d --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' -p 8200:8200 vault:latest
+```
 To verify if vault started properly use `docker logs jx-k3s-vault`.
 
 Next enable kubernetes auth in vault.


### PR DESCRIPTION
# Description

As per the documentation on https://jenkins-x.io/v3/admin/platforms/k3s/#vault it wasn't possible to set up vault in k3s on WSL2 hence breaking the setup process.


Fixes # (issue)
This issue was resolved by mentioning `-p <PORT NUMBER>:<PORT NUMBER>` instead of `--net host`.
# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

