### PR TITLE
fix: resolve DNS hostnames from within pod in minikube

### DIFF
--- a/content/en/blog/news/2022-04-22-k8s-122-tekton.md
+++ b/content/en/blog/news/2022-04-22-k8s-122-tekton.md
@@ -57,3 +57,23 @@ In the current version of Tekton used by Jenkins X, the resource `requests` are 
 To prepare for upgrade, you should create a PR applying the changes described above. We done some tests on applying the changes to the current version of Jenkins X/Tekton, and it seemed to work. But - that does not mean it will work on your machines or even pipelines! 
 
 So, please prepare for upgrade now! We want people to have a safe upgrade experience. If you have questions, you can find us on [Slack](https://kubernetes.slack.com/messages/C9MBGQJRH).
+
+#### Cannot resolve DNS hostname outside of cluster
+With the recent upgrade of base image of ghcr.io/jenkins-x/jx-boot:3.2.338 to alpine linux v3.15 in some of the local providers like minikube, the pod's DNS nameserver is not able to resolve DNS hostname outside k8s cluster like github.com. 
+
+To resolve this issue you need to add [custom dnspolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) on your local cluster repository in below files with this change
+```yaml
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 8.8.8.8
+        options:
+          - name: ndots
+            value: "1"
+```
+
+1. boot job yaml file which is generated from [cluster git repository](https://github.com/jx3-gitops-repositories/jx3-minikube/blob/main/versionStream/git-operator/job.yaml#L56) replacing `dnsPolicy: ClusterFirst`
+2. [PR pipeline](https://github.com/jx3-gitops-repositories/jx3-minikube/blob/main/.lighthouse/jenkins-x/pullrequest.yaml#L31) under `podTemplate`
+3. [Release pipeline](https://github.com/jx3-gitops-repositories/jx3-minikube/blob/main/.lighthouse/jenkins-x/release.yaml#L32) under `podTemplate`
+
+To see examples of what changes you need to apply to your cluster git repository you may investigate this [PR](https://github.com/jx3-gitops-repositories/jx3-minikube/pull/7/files)


### PR DESCRIPTION
More info on this can be found at this [slack chat](https://kubernetes.slack.com/archives/C9MBGQJRH/p1652161645265129)

# Description

with recent upgrade of alpine linux in image `ghcr.io/jenkins-x/jx-boot:3.2.338`, minikube boot pod and pipelines are failing with error as `Could not resolve host: github.com`

Fixes # (issue)
Need to add custom `dnspolicy` to boot and pipeline pods.
