### PR TITLE
fix: add docs around multiple named ngrok tunnels

### DIFF
--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -258,13 +258,43 @@ git pull
 jx gitops requirements edit --domain <external-ip>.nip.io
 ```
 
-- Next, download and install [ngrok](https://ngrok.com/). Run this in a new terminal window/tab:
+#### Ngrok
 
-```bash
-ngrok http 8080
+Next, download and install [ngrok](https://ngrok.com/).
+Log into ngrok account and get the ngrok auth token (Authenticated sessions can run for unlimited time, unauthenticated sessions expire in 1.5 hours):
+
+Create a ngrok config file at `~/.config/ngrok/ngrok.yml` with the following content (replace `<ngrok-auth-token>` with the auth token from the ngrok account):
+
+```yaml
+authtoken: <ngrok-auth-token>
+tunnels:
+  hook:
+    proto: http
+    addr: 8080
+    schemes:
+      - http
+  ui:
+    proto: http
+    addr: 9090
+    schemes:
+      - http
+version: "2"
+region: us
 ```
 
-- Once this tunnel is open, paste the ngrok url (without http and https) in the hook field in the helmfiles/jx/jxboot-helmfile-resources-values.yaml file in the cluster git repository.
+Verify that the config is correct using:
+
+```bash
+ngrok config check
+```
+
+Run this in a new terminal window/tab:
+
+```bash
+ngrok start --all
+```
+
+- Once this tunnel is open, paste the ngrok url (without http) in the hook field in the helmfiles/jx/jxboot-helmfile-resources-values.yaml file in the cluster git repository.
 - commit and push the changes.
 
 ```bash


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

# Description

It's possible to run multiple named tunnels using ngrok for unlimited time. 

Fixes # (issue)

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

