### PR TITLE
fix: changing Docs to Documentation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -117,7 +117,7 @@ privacy_policy = "https://policies.google.com/privacy"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
-version_menu = "Docs"
+version_menu = "Documentation"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/jenkins-x/jx-docs"

--- a/content/en/v3/_index.md
+++ b/content/en/v3/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Jenkins X 3.x
-linktitle: Docs
+linktitle: Documentation
 type: docs
 weight: 45
 aliases:


### PR DESCRIPTION
# Description
The PR changes the Docs to Documentation in NavBar and in the SideBar

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

