### PR TITLE
fix: Make regeneration of plugin docs work again

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -21,15 +21,4 @@ jobs:
       - name: create-pr
         uses: docker://ghcr.io/jenkins-x/jx-project:latest
         with:
-          args:
-          - pullrequest
-          - --batch.mode
-          - --title
-          - chore: regenerated plugin docs
-          - --body
-          - Created by this action run: https://github.com/jenkins-x/jx-docs/runs/${{ github.run_id }}?check_suite_focus=true
-          - --label
-          - updatebot
-          - --push
-          - --git-token
-          - ${{ secrets.GIT_BOT_TOKEN }}
+          args: pullrequest --batch.mode --title "chore: regenerated plugin docs" --body "Created by this action run: https://github.com/jenkins-x/jx-docs/runs/${{ github.run_id }}?check_suite_focus=true" --label updatebot --push --git-token ${{ secrets.GIT_BOT_TOKEN }}


### PR DESCRIPTION
# Description

Regeneration of plugin docs have not worked in a while due to the addition of a branch protection rule.

This is an attempt of fixing that by creating pull request to be merged by lighthouse.

It's not possible to give Github Actions permissions to psu to a protected branch as far as I understand this: https://github.com/orgs/community/discussions/25305

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

