### PR TITLE
fix: Make regeneration of plugin docs work again

### DIFF
--- a/.github/actions/create-pr-for-plugin-docs.yaml
+++ b/.github/actions/create-pr-for-plugin-docs.yaml
@@ -1,0 +1,25 @@
+name: create-plugin-pr
+description: Create pr for regenerated plugin docs
+inputs:
+  token:
+    description: GitHub token
+    required: true
+  run_id:
+    description: GitHub action run id
+    required: true
+runs:
+  using: 'docker'
+  image: 'docker://ghcr.io/jenkins-x/jx-project:latest'
+  args:
+  - pullrequest
+  - --batch.mode
+  - --title
+  - chore: regenerated plugin docs
+  - --body
+  - Created by this action run: https://github.com/jenkins-x/jx-docs/runs/${{ inputs.run_id }}?check_suite_focus=true
+  - --label
+  - updatebot
+  - --push
+  - --git-token
+  - ${{ inputs.token }}
+    

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           entrypoint: ./regen-plugins.sh
       - name: create-pr
-        uses: docker://ghcr.io/jenkins-x/jx-project:latest
+        uses: ./.github/actions/create-pr-for-plugin-docs
         with:
-          args: pullrequest --batch.mode --title "chore: regenerated plugin docs" --body "Created by this action run: https://github.com/jenkins-x/jx-docs/runs/${{ github.run_id }}?check_suite_focus=true" --label updatebot --push --git-token ${{ secrets.GIT_BOT_TOKEN }}
+          token: ${{ secrets.GIT_BOT_TOKEN }}
+          run_id: ${{ github.run_id }}


### PR DESCRIPTION
# Description

Regeneration of plugin docs have not worked in a while due to the addition of a branch protection rule.

This is an attempt of fixing that by creating pull request to be merged by lighthouse.

It's not possible to give Github Actions permissions to psu to a protected branch as far as I understand this: https://github.com/orgs/community/discussions/25305

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

