### PR TITLE
fix: Make regeneration of plugin docs work again

### DIFF
--- a/.github/actions/create-pr-for-plugin-docs/action.yaml
+++ b/.github/actions/create-pr-for-plugin-docs/action.yaml
@@ -1,4 +1,4 @@
-name: create-plugin-pr
+name: create-pr-for-plugin-docs
 description: Create pr for regenerated plugin docs
 inputs:
   token:


### PR DESCRIPTION
# Description

Regeneration of plugin docs have not worked in a while due to the addition of a branch protection rule.

This is an attempt of fixing that by creating pull request to be merged by lighthouse.

It's not possible to give Github Actions permissions to psu to a protected branch as far as I understand this: https://github.com/orgs/community/discussions/25305

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

