### PR TITLE
fix: Make regeneration of plugin docs work again

### DIFF
--- a/regen-plugins.sh
+++ b/regen-plugins.sh
@@ -7,6 +7,7 @@ else
   echo "lets setup git"
   git config user.name github-actions
   git config user.email github-actions@github.com
+  git config --global --add safe.directory /github/workspace  
 fi
 
 git clone https://github.com/jenkins-x-plugins/jx-plugin-doc


### PR DESCRIPTION
# Description

Regeneration of plugin docs have not worked in a while due to the addition of a branch protection rule.

This is an attempt of fixing that by creating pull request to be merged by lighthouse.

It's not possible to give Github Actions permissions to psu to a protected branch as far as I understand this: https://github.com/orgs/community/discussions/25305

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

