### PR TITLE
fix: Make regeneration of plugin docs work again

### DIFF
--- a/regen-plugins.sh
+++ b/regen-plugins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 if [ -z "$GITHUB_ACTIONS" ]
 then
   echo "not setting up git as not in a GitHub Action"
@@ -16,8 +18,6 @@ cd jx-plugin-doc
 make build
 cd ..
 
-echo "build the tool"
-
 ls -al 
 
 DIR=$(pwd)
@@ -31,18 +31,9 @@ ls jx-plugins
 echo generated 
 ls -al content/en/v3/develop/reference/jx
 
-echo git commit
-
 git add content/en/v3/develop/reference/jx
 git status
 
-if [ -z "$DISABLE_COMMIT" ]
-then
-    echo "adding generated content"
-    git commit -a -m "chore: regenerated plugin docs"
-    git push
-else
-    echo "disabled commiting changes"
-fi
+git checkout -b regen-plugin-docs-`date +%Y%m%d-%H%M%S`
 
 echo "complete"


### PR DESCRIPTION
# Description

Regeneration of plugin docs have not worked in a while due to the addition of a branch protection rule.

This is an attempt of fixing that by creating pull request to be merged by lighthouse.

It's not possible to give Github Actions permissions to psu to a protected branch as far as I understand this: https://github.com/orgs/community/discussions/25305

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

