### PR TITLE
fix: changing docker-compose to docker compose in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,31 +18,31 @@ generate: ## Let's hugo generate the site into the configured directory
 
 .PHONY: compose-up
 compose-up: ## Runs Hugo in container in background via Docker Compose
-	docker-compose up -d server
+	docker compose up -d server
 
 .PHONY: compose-down
 compose-down: ## Stops Hugo container
-	docker-compose down
+	docker compose down
 
 .PHONY: compose-restart
 compose-restart: ## Restarts Hugo container
-	docker-compose restart server
+	docker compose restart server
 
 .PHONY: compose-stop
 compose-stop: ## Stops Hugo container
-	docker-compose stop server
+	docker compose stop server
 
 .PHONY: compose-logs
 compose-logs: ## Display logs from Hugo container
-	docker-compose logs -f server
+	docker compose logs -f server
 
 .PHONY: spellcheck
 spellcheck: ## Runs spell checker using Docker Compose in foreground
-	docker-compose up spellchecker
+	docker compose up spellchecker
 
 .PHONY: linkcheck
 linkcheck: generate ## Runs spell checker using Docker Compose in foreground
-	docker-compose run linkchecker
+	docker compose run linkchecker
 
 .PHONY: clean
 clean: ## Deletes temporary/generated files

--- a/content/en/community/documentation/_index.md
+++ b/content/en/community/documentation/_index.md
@@ -59,7 +59,7 @@ Use this:
 
 The first thing you'll need to make use of this approach is Docker installed on your local environment.
 How to install a Docker engine depends on your platform etc., so best to head over to [Docker](https://docs.docker.com/install/) to find the right one.
-Next, install docker-compose from the [installation documents](https://docs.docker.com/compose/install/).
+Next, you have install docker compose v2 from the [installation guide](https://docs.docker.com/compose/install/).
 
 To make it as simple as possible, we use the [docker image](https://hub.docker.com/r/klakegg/hugo) recommended in the hugo [documentation](https://gohugo.io/getting-started/installing/#docker), and have setup a [`docker-compose.yml`](https://github.com/jenkins-x/jx-docs/blob/main/docker-compose.yml) file that will help you start up a preview server with a few helpful options.
 


### PR DESCRIPTION
# Description
This PR changes the docker-compose to docker compose.

**_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._**

This PR does not add any new dependency.

Fixes #3654 

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

