### PR TITLE
fix: add jx-community repo link

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -17,6 +17,7 @@ We value respect and inclusiveness and follow the [CDF Code of Conduct](/communi
 
 Join us on [Slack](/community/#slack), and during [Office Hours](/community/#office-hours) to ask questions and tell us what you are building.
 Upcoming [events and webinars](/community/#events--webinars) are shown on our [Event Calendar](/community/calendar) or announced on [Twitter](https://twitter.com/jenkinsxio).
+Visit [jx-community](https://github.com/jenkins-x/jx-community/) repository to read meeting notes.
 
 <!-- {{< figure src="/images/community/GoCommunity-background.png" class="img-thumbnail" >}}
 image by Ashley McNamara, [creative commons license](https://github.com/ashleymcnamara/gophers/blob/master/GoCommunity.png) -->


### PR DESCRIPTION
# Description
This PR adds jx-community link.
![image](https://user-images.githubusercontent.com/55191777/199709073-76d8d987-4438-40ff-a6d0-994cce89cdb6.png)

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

