### PR TITLE
ci: fix jx preview prs

### DIFF
--- a/.lighthouse/jenkins-x/preview.yaml
+++ b/.lighthouse/jenkins-x/preview.yaml
@@ -24,13 +24,9 @@ spec:
           steps:
             - image: klakegg/hugo:0.101.0-ext-alpine
               name: git-submodules
-              command:
-                - git
-              args:
-                - submodule
-                - update
-                - --init
-                - --recursive
+              script: |
+                git config --global --add safe.directory /workspace/source
+                git submodule update --init --recursive
 
             - image: klakegg/hugo:0.101.0-ext-alpine
               name: update-content
@@ -52,6 +48,7 @@ spec:
                   memory: 512Mi
               script: |
                 #!/bin/sh
+                git config --global --add safe.directory /workspace/source
                 hugo -d tmp-website --enableGitInfo --baseURL https://${REPO_NAME}-jx-${REPO_OWNER}-${REPO_NAME}-pr-${PULL_NUMBER}.${DOMAIN}/
 
             - image: ghcr.io/jenkins-x/jx-boot:3.2.197
@@ -68,7 +65,7 @@ spec:
                 source .jx/variables.sh
                 /kaniko/executor --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=gcr.io/jenkinsxio-324711/jx-docs:$VERSION
 
-            - image: ghcr.io/jenkins-x/jx-preview:0.0.172
+            - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.225
               name: promote-jx-preview
               resources: {}
               script: |

--- a/charts/preview/templates/ingress.yaml
+++ b/charts/preview/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -8,17 +8,20 @@ spec:
   rules:
   - http:
       paths:
-      - backend:
-          serviceName: {{ .Values.service.name }}
-          servicePort: 80
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ .Values.service.name }}
+            port:
+              number: 80
     host: {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- if .Values.jxRequirements.ingress.tls.production }}
-    secretName: "jx/tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
+    secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
 {{- else }}
-    secretName: "jx/tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s"
+    secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

# Description

doc PRs are failing because of 
```
fatal: unsafe repository ('/workspace/source' is owned by someone else)
--
  |   |   |   | To add an exception for this directory, call:
  |   |   |   |  
  |   |   |   | git config --global --add safe.directory /workspace/source
```

Ideally this should should be added in git clone step though!

Fixes # (issue)

# Checklist:

- [ ] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ ] Any dependent changes have already been merged.

