### PR TITLE
fix: linux installation instructions

### DIFF
--- a/content/en/docs/_index.html
+++ b/content/en/docs/_index.html
@@ -156,7 +156,13 @@ brew install jenkins-x/jx/jx
 
 {{<highlight sh>}}
 # Download the `.tar` file, unarchive it.
-curl -L "https://github.com/jenkins-x/jx/releases/download/$(curl --silent https://api.github.com/repos/jenkins-x/jx/releases/latest | jq -r '.tag_name')/jx-darwin-amd64.tar.gz" | tar xzv "jx"
+curl -LO https://github.com/jenkins-x/jx/releases/download/latest/jx-linux-amd64.tar.gz -LO https://github.com/jenkins-x/jx/releases/download/latest/jx-linux-amd64.tar.gz.sig
+
+# Verify the signature.
+osign verify-blob --key https://raw.githubusercontent.com/jenkins-x/jx/main/jx.pub --signature jx-linux-amd64.tar.gz.sig jx-linux-amd64.tar.gz
+
+# Unarchive the file.
+tar -zxvf jx-linux-amd64.tar.gz
 
 # Add `jx` to your path
 sudo mv jx /usr/local/bin


### PR DESCRIPTION
This fixes the current way of install Jenkins X on Linux, working with Fedora 37 and ZSH

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

