### PR TITLE
fix: minikube install

### DIFF
--- a/content/en/v3/admin/platforms/minikube/_index.md
+++ b/content/en/v3/admin/platforms/minikube/_index.md
@@ -41,7 +41,7 @@ minikube delete
 - You need to create a `minikube` cluster via the following command:
 
 ```bash
-minikube start --cpus 4 --memory 6048 --disk-size=100g --addons=ingress
+minikube start --cpus 4 --memory 6048 --disk-size=100g --addons=ingress --kubernetes-version=1.24
 ```
 
 ## Setup


### PR DESCRIPTION
Adding argument to  minikube to set the kubernetes version. Minikube uses 1.25 by default which we do not support yet. 