### PR TITLE
fix: add version tag to k3s install command

### DIFF
--- a/content/en/v3/admin/platforms/k3s/_index.md
+++ b/content/en/v3/admin/platforms/k3s/_index.md
@@ -31,7 +31,7 @@ Make sure you have created a cluster using k3s.
 If you dont have an existing k3s cluster, you can install one by running:
 
 ```bash
-curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.24 sh -s - --write-kubeconfig-mode 644
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-config
 # Set it also in the bashrc or zshrc file, or you can flatten both of these configs into a single file
 export KUBECONFIG=~/.kube/config:~/.kube/k3s-config


### PR DESCRIPTION
# Description
I was following the k3s guide and the k3s by default install 1.25, which is not support by **jx** yet.
So, we should add the version tag which installs 1.24.

Fixes # (issue)

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

