### PR TITLE
chore: add alert that Lens v6 is not supported

### DIFF
--- a/content/en/v3/develop/ui/lens.md
+++ b/content/en/v3/develop/ui/lens.md
@@ -6,6 +6,10 @@ description: desktop Jenkins X Console based on Lens
 weight: 50
 ---
     
+{{< alert color="warning" >}}
+Lens v6 or higher is not supported.
+{{< /alert >}}
+
 [Lens](https://k8slens.dev/) is a desktop console for Kubernetes which runs locally on your laptop as a desktop application.
 
 ![](/images/lens/lens.png)


### PR DESCRIPTION
# Description

Add a simple alert that Lens v6 is not supported

Fixes #3664

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

