### PR TITLE
chore: add alerts that breakpoint used by jx-lens no longer function

### DIFF
--- a/content/en/blog/news/2021-debug-tekton.md
+++ b/content/en/blog/news/2021-debug-tekton.md
@@ -10,6 +10,10 @@ aliases: []
 author: James Strachan
 ---
 
+{{< alert color="warning" >}}
+`TaskRun` breakpoint functionality is no longer supported since Tekton 0.29.0 upgrades in `3.2.298`. For more info see [Kubernetes 1.22 - Breaking change!](/blog/2022/04/22/kubernetes-1.22-tekton/).
+{{< /alert >}}
+
 Tekton recently introduced a [debug feature](https://github.com/tektoncd/pipeline/blob/main/docs/debug.md#debug) when you create `TaskRun` resources so that steps can be paused at a breakpoint until told to move forwards so that you can diagnose why pipeline steps fail.
 
 The latest Tekton release only supports breakpoints on `TaskRun` resources but there is a [Pull Request #4145](https://github.com/tektoncd/pipeline/pull/4145) to add support also to debugging `PipelineRun` resources as well. If you are reading this please add your thumbs up emoji feedback to the [PR #4145](https://github.com/tektoncd/pipeline/pull/4145)

--- a/content/en/v3/develop/pipelines/debugging.md
+++ b/content/en/v3/develop/pipelines/debugging.md
@@ -6,6 +6,10 @@ description: Debugging pipelines in Jenkins X
 weight: 410
 ---
 
+{{< alert color="warning" >}}
+`TaskRun` breakpoint functionality is no longer supported since Tekton 0.29.0 upgrades in `3.2.298`. For more info see [Kubernetes 1.22 - Breaking change!](/blog/2022/04/22/kubernetes-1.22-tekton/).
+{{< /alert >}}
+
 Here is a demo which shows how to debug pipelines:
 
 <iframe width="850" height="500" src="https://www.youtube.com/embed/QqTaclB6-oI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
# Description

Adds simple alert that breakpoint used by jx-lens no longer functions

Fixes # 3694

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

