### PR TITLE
fix: Update _index.md versions

### DIFF
--- a/content/en/community/code/_index.md
+++ b/content/en/community/code/_index.md
@@ -30,8 +30,8 @@ If you're struggling at any point in this contribution guide, reach out to the J
 To contribute to Jenkins X jx binary, you will need:
 
 * [Git](https://git-scm.com) and a [GitHub](https://github.com) account
-* [Go](https://golang.org/) `1.18.X`, with support for compiling to `linux/amd64`
-* [golangci-lint](https://github.com/golangci/golangci-lint)`1.46.2`, wich will be used to lint your code later
+* [Go](https://golang.org/) `1.23.X`, with support for compiling to `linux/amd64`
+* [golangci-lint](https://github.com/golangci/golangci-lint)`1.50.1`, wich will be used to lint your code later
 * [pre-commit](https://pre-commit.com/#install) - once installed, ensure you're at the root of the repository which contains a `.pre-commit-config.yaml` configuration file, then:
 
 ```sh
@@ -40,7 +40,7 @@ pre-commit install
 
 ### Install Go
 
-We recommend `1.17.X` version of go as the pull request checks run against this version.
+We recommend `1.23.X` version of go as the pull request checks run against this version.
 
 The installation of Go should take only a few minutes. You have more than one option to get Go up and running on your machine.
 
@@ -51,7 +51,7 @@ If you are having trouble following the installation guides for go, check out [G
 If you are a macOS user and have [Homebrew](https://brew.sh/) installed on your machine, installing Go is as simple as the following command:
 
 ```sh
-brew install go@1.15
+brew install go@1.23
 ```
 
 #### Install Go via GVM
@@ -83,7 +83,7 @@ go version
 You should see something similar to the following written to the console (on macOS). Note that the version here reflects the most recent version of Go as of the last update for this page:
 
 ```sh
-go version go1.17.x darwin/amd64
+go version go1.23.x darwin/amd64
 ```
 
 Next, make sure that you set up your `GOPATH` [as described in the installation guide](https://github.com/golang/go/wiki/SettingGOPATH).

--- a/content/en/v3/about/concepts/deployment-lifecycle.md
+++ b/content/en/v3/about/concepts/deployment-lifecycle.md
@@ -241,7 +241,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.17.9
+        - image: golang:1.23.2
           name: build-make-linux
           resources: {}
           script: |

--- a/content/en/v3/develop/environments/preview.md
+++ b/content/en/v3/develop/environments/preview.md
@@ -184,7 +184,7 @@ e.g. here is an additional step to curl the preview URL after the `jx preview cr
 ```yaml
 ... 
 - name: test-preview
-  image: golang:1.15
+  image: golang:1.23
   script: |
     #!/usr/bin/env sh
     source .jx/variables.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jenkins-x/jx-docs
 
-go 1.17
+go 1.23
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect


### PR DESCRIPTION
Per jx repo - go version used is 1.23 and golang ci expected version is 1.50.1  https://github.com/jenkins-x/jx/blob/274bb14e07bada58978129a9754352316a4bf568/hack/linter.sh#L12 https://github.com/jenkins-x/jx/blob/274bb14e07bada58978129a9754352316a4bf568/Dockerfile-go

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [ X] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [X ] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [X ] Any dependent changes have already been merged.

