### PR TITLE
fix: remove broken reference to discourse page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: true
-contact_links:
-  - name: Ask a question
-    url: https://jenkinsx.discourse.group/
-    about: For increased visibility, please post questions on the discourse forum.


### PR DESCRIPTION
* fixes issue https://github.com/jenkins-x/jx-docs/issues/3717
Signed-off-by: CJ Steiner <clintonsteiner@gmail.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [ X] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [ X] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [ X] Any dependent changes have already been merged.

