### PR TITLE
add instruction regarding connect to eks

### DIFF
--- a/content/en/v3/admin/platforms/eks/_index.md
+++ b/content/en/v3/admin/platforms/eks/_index.md
@@ -79,6 +79,8 @@ Note: remember to create the Git repositories below in your Git Organization rat
       terraform plan
       terraform apply
 ```
+- Connect to the cluster using the command shown in the field `connect` of the output of `terraform apply`. To show 
+  it again run `terraform output`.
 
 - Tail the Jenkins X installation logs
 


### PR DESCRIPTION
# Description

To simplify the module the terraform-aws-eks-jx module it doesn't run `aws eks update-kubeconfig` any more

# Checklist:

- [x] I have mentioned the appropriate type(scope), as referenced [here](https://jenkins-x.io/community/code/#the-commit-message) in the commit message and PR title for the semantic checks to pass.
- [x] I have signed off the commit, as per instructions mentioned [here](https://jenkins-x.io/community/code/#how-to-sign-your-commits).
- [x] Any dependent changes have already been merged.

